### PR TITLE
Add bulk product CSV upload with image storage

### DIFF
--- a/src/components/admin/BulkProductUpload.tsx
+++ b/src/components/admin/BulkProductUpload.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/use-toast';
+
+// Simple CSV parser (no quoted field support)
+async function parseCsv(file: File): Promise<Record<string, string>[]> {
+  const text = await file.text();
+  const lines = text.trim().split(/\r?\n/);
+  if (lines.length === 0) return [];
+  const headers = lines[0].split(',').map(h => h.trim());
+  return lines.slice(1).filter(Boolean).map(line => {
+    const values = line.split(',');
+    const obj: Record<string, string> = {};
+    headers.forEach((h, idx) => {
+      obj[h] = (values[idx] || '').trim();
+    });
+    return obj;
+  });
+}
+
+interface Props {
+  onComplete?: () => void;
+}
+
+export const BulkProductUpload = ({ onComplete }: Props) => {
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [imageFiles, setImageFiles] = useState<FileList | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const { toast } = useToast();
+
+  const handleUpload = async () => {
+    if (!csvFile) return;
+    setUploading(true);
+    try {
+      const rows = await parseCsv(csvFile);
+      for (const row of rows) {
+        const imageName = row.image || row.image_file;
+        let image_url: string | null = null;
+        if (imageName && imageFiles) {
+          const file = Array.from(imageFiles).find(f => f.name === imageName);
+          if (file) {
+            const { data, error } = await supabase.storage
+              .from('product-images')
+              .upload(`products/${Date.now()}-${file.name}`, file);
+            if (!error && data) {
+              const urlRes = supabase.storage
+                .from('product-images')
+                .getPublicUrl(data.path);
+              image_url = urlRes.data.publicUrl;
+            }
+          }
+        }
+        await supabase.from('products').insert({
+          name: row.name,
+          description: row.description || null,
+          category: row.category,
+          price_per_day: row.price_per_day ? Number(row.price_per_day) : 0,
+          stock_quantity: row.stock_quantity ? Number(row.stock_quantity) : 0,
+          availability_status: row.availability_status || 'Available',
+          image_url,
+        });
+      }
+      toast({ title: 'Success', description: 'Products uploaded successfully.' });
+      setCsvFile(null);
+      setImageFiles(null);
+      if (onComplete) onComplete();
+    } catch (err) {
+      console.error(err);
+      toast({
+        title: 'Error',
+        description: 'Failed to upload products. Check file format.',
+        variant: 'destructive',
+      });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <Input type="file" accept=".csv" onChange={e => setCsvFile(e.target.files?.[0] || null)} />
+      </div>
+      <div>
+        <Input type="file" accept="image/*" multiple onChange={e => setImageFiles(e.target.files)} />
+      </div>
+      <Button onClick={handleUpload} disabled={!csvFile || uploading}>
+        {uploading ? 'Uploading...' : 'Upload'}
+      </Button>
+    </div>
+  );
+};
+
+export default BulkProductUpload;

--- a/src/components/admin/ProductManagement.tsx
+++ b/src/components/admin/ProductManagement.tsx
@@ -14,6 +14,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/components/ui/use-toast';
 // import { LoadingState } from '@/components/ui/LoadingState'; // Removed LoadingState
 import { Skeleton } from '@/components/ui/skeleton'; // Added Skeleton
+import { BulkProductUpload } from './BulkProductUpload';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
 import type { Product as GlobalProduct, AvailabilityStatus } from '@/types/types'; // Import global Product and AvailabilityStatus
 
@@ -50,6 +51,7 @@ export const ProductManagement = () => {
   const [loading, setLoading] = useState(true);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [isBulkDialogOpen, setIsBulkDialogOpen] = useState(false);
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
   const [productToDelete, setProductToDelete] = useState<Product | null>(null);
 
@@ -412,6 +414,21 @@ export const ProductManagement = () => {
             </Button>
           </DialogTrigger>
           {renderProductForm(handleCreateProduct, "Create New Product", "Create Product")}
+        </Dialog>
+
+        {/* Bulk Upload Dialog */}
+        <Dialog open={isBulkDialogOpen} onOpenChange={setIsBulkDialogOpen}>
+          <DialogTrigger asChild>
+            <Button variant="outline" className="ml-2" onClick={() => setIsBulkDialogOpen(true)}>
+              Bulk Upload
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Bulk Upload Products</DialogTitle>
+            </DialogHeader>
+            <BulkProductUpload onComplete={() => { setIsBulkDialogOpen(false); fetchProducts(); }} />
+          </DialogContent>
         </Dialog>
 
         {/* Edit Product Dialog */}


### PR DESCRIPTION
## Summary
- enable bulk CSV upload with new `BulkProductUpload` component
- integrate bulk upload dialog into ProductManagement

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6e695bdc832b950adb470d035924