### PR TITLE
Fix Supabase env var name

### DIFF
--- a/scripts/migrations.ts
+++ b/scripts/migrations.ts
@@ -4,7 +4,7 @@ import { createClient } from '@supabase/supabase-js';
 dotenv.config({ path: '.env.local' });
 
 const supabaseAdmin = createClient(
-  process.env.VITE_PUBLIC_SUPABASE_URL!,
+  (process.env.SUPABASE_URL || process.env.VITE_PUBLIC_SUPABASE_URL)!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!
 );
 

--- a/scripts/seed-data.ts
+++ b/scripts/seed-data.ts
@@ -2,7 +2,7 @@ import { createClient } from '@supabase/supabase-js';
 // import { Customer, Equipment, Booking } from '../src/lib/queries/types';
 
 const supabaseAdmin = createClient(
-  process.env.VITE_PUBLIC_SUPABASE_URL!,
+  (process.env.SUPABASE_URL || process.env.VITE_PUBLIC_SUPABASE_URL)!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!
 );
 

--- a/scripts/seed-equipment.ts
+++ b/scripts/seed-equipment.ts
@@ -3,7 +3,8 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const supabaseUrl = process.env.VITE_PUBLIC_SUPABASE_URL;
+// Use SUPABASE_URL if available for consistency
+const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_PUBLIC_SUPABASE_URL;
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 if (!supabaseUrl || !supabaseServiceKey) {

--- a/scripts/seed-users.ts
+++ b/scripts/seed-users.ts
@@ -4,7 +4,8 @@ import { randomUUID } from 'crypto';
 
 dotenv.config();
 
-const supabaseUrl = process.env.VITE_PUBLIC_SUPABASE_URL;
+// Use SUPABASE_URL to match the environment variable name
+const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_PUBLIC_SUPABASE_URL;
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 if (!supabaseUrl || !supabaseServiceKey) {


### PR DESCRIPTION
## Summary
- look for `SUPABASE_URL` before `VITE_PUBLIC_SUPABASE_URL` in seed scripts

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e317146f4832b8291347f650e7f1f