### PR TITLE
Add Supabase env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_PUBLIC_SUPABASE_URL=your-supabase-url
+VITE_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/README.md
+++ b/README.md
@@ -71,3 +71,14 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Environment variables
+
+Create a `.env` file based on `.env.example` and provide your Supabase details:
+
+```env
+VITE_PUBLIC_SUPABASE_URL=<your-supabase-url>
+VITE_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+```
+
+These values are required for the application to connect to Supabase during development and builds.

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,9 @@
 import { createClient as supabaseCreateClient } from '@supabase/supabase-js'; // Renamed import
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://abofxrgdxfzrhjbvhdkj.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFib2Z4cmdkeGZ6cmhqYnZoZGtqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg1MTE5OTYsImV4cCI6MjA2NDA4Nzk5Nn0.n3j6qicmmHvCOLWDUClCfyir2StsOMmyNWedghySo-0";
+const SUPABASE_URL = import.meta.env.VITE_PUBLIC_SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY =
+  import.meta.env.VITE_PUBLIC_SUPABASE_ANON_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- add `.env.example` for Supabase variables
- use `import.meta.env` in Supabase client
- document environment variables in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8262308c832b8c72ec42cd169c0e