### PR TITLE
Switch to papaparse for CSV upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",
+    "papaparse": "^5.4.1",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",

--- a/src/components/admin/BulkProductUpload.tsx
+++ b/src/components/admin/BulkProductUpload.tsx
@@ -1,22 +1,22 @@
 import { useState } from 'react';
+import Papa from 'papaparse';
 import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/components/ui/use-toast';
 
-// Simple CSV parser (no quoted field support)
-async function parseCsv(file: File): Promise<Record<string, string>[]> {
-  const text = await file.text();
-  const lines = text.trim().split(/\r?\n/);
-  if (lines.length === 0) return [];
-  const headers = lines[0].split(',').map(h => h.trim());
-  return lines.slice(1).filter(Boolean).map(line => {
-    const values = line.split(',');
-    const obj: Record<string, string> = {};
-    headers.forEach((h, idx) => {
-      obj[h] = (values[idx] || '').trim();
+function parseCsv(file: File): Promise<Record<string, string>[]> {
+  return new Promise((resolve, reject) => {
+    Papa.parse<Record<string, string>>(file, {
+      header: true,
+      skipEmptyLines: true,
+      complete: results => {
+        resolve(results.data as Record<string, string>[]);
+      },
+      error: err => {
+        reject(err);
+      },
     });
-    return obj;
   });
 }
 


### PR DESCRIPTION
## Summary
- use Papaparse library for parsing CSV files
- add papaparse dependency

## Testing
- `npm run lint --silent` *(fails: Cannot find package '@eslint/js')*
- `npm test --silent` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e82645550832bb6402fdcc72d5816