### PR TITLE
Enable site asset uploads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import ErrorBoundary from "@/components/layout/ErrorBoundary";
 import { AuthProvider } from "@/hooks/useAuth";
+import { SiteAssetsProvider } from "@/hooks/useSiteAssets";
 import Index from "./pages/Index";
 import Equipment from "./pages/Equipment";
 import Book from "./pages/Book";
@@ -23,10 +24,11 @@ const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
       <AuthProvider>
-        <Toaster />
-        <Sonner />
-        <ErrorBoundary>
-          <BrowserRouter>
+        <SiteAssetsProvider>
+          <Toaster />
+          <Sonner />
+          <ErrorBoundary>
+            <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/equipment" element={<Equipment />} />
@@ -53,6 +55,7 @@ const App = () => (
           </Routes>
         </BrowserRouter>
         </ErrorBoundary>
+        </SiteAssetsProvider>
       </AuthProvider>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { Calendar, Users, BarChart3, Package, Settings, Eye, UserPlus, MapPin, CheckSquare, FileText } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { Button } from '@/components/ui/button';
+import { useSiteAssets } from '@/hooks/useSiteAssets';
 
 interface AdminSidebarProps {
   activeSection?: string;
@@ -11,6 +12,7 @@ interface AdminSidebarProps {
 
 export const AdminSidebar = ({ activeSection, onSectionChange }: AdminSidebarProps) => {
   const { profile, hasPermission, signOut } = useAuth();
+  const { assets } = useSiteAssets();
   const [currentSection, setCurrentSection] = useState(activeSection || 'dashboard');
 
   const handleSectionChange = (section: string) => {
@@ -40,9 +42,9 @@ export const AdminSidebar = ({ activeSection, onSectionChange }: AdminSidebarPro
     <div className="w-64 bg-white border-r border-gray-200">
       <div className="p-6">
         <div className="flex items-center mb-4">
-          <img 
-            src="/lovable-uploads/89b8e502-c516-4f94-841b-813b84bedea8.png" 
-            alt="Travel Light Aruba" 
+          <img
+            src={assets.logo || '/lovable-uploads/89b8e502-c516-4f94-841b-813b84bedea8.png'}
+            alt="Travel Light Aruba"
             className="h-8 w-auto mr-3"
           />
           <h2 className="text-xl font-bold text-gray-900">Admin Panel</h2>

--- a/src/components/admin/SiteSettings.tsx
+++ b/src/components/admin/SiteSettings.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useSiteAssets } from '@/hooks/useSiteAssets';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+
+const ASSETS = [
+  { key: 'hero_image', label: 'Hero Background' },
+  { key: 'logo', label: 'Website Logo' },
+  { key: 'favicon', label: 'Favicon' }
+] as const;
+
+type AssetKey = (typeof ASSETS)[number]['key'];
+
+export const SiteSettings = () => {
+  const { assets, refresh } = useSiteAssets();
+  const { toast } = useToast();
+  const [files, setFiles] = useState<Record<AssetKey, File | null>>({
+    hero_image: null,
+    logo: null,
+    favicon: null
+  });
+  const [uploading, setUploading] = useState<AssetKey | null>(null);
+
+  const handleFileChange = (key: AssetKey, file: File | null) => {
+    setFiles(prev => ({ ...prev, [key]: file }));
+  };
+
+  const uploadAsset = async (key: AssetKey) => {
+    const file = files[key];
+    if (!file) return;
+    setUploading(key);
+    const path = `${key}/${Date.now()}-${file.name}`;
+    const { data, error } = await supabase.storage
+      .from('site-assets')
+      .upload(path, file, { upsert: true });
+    if (error) {
+      toast({ title: 'Error', description: 'Upload failed', variant: 'destructive' });
+      setUploading(null);
+      return;
+    }
+    await supabase.from('content_images').upsert(
+      { image_key: key, file_path: data.path, file_size: file.size, mime_type: file.type },
+      { onConflict: 'image_key' }
+    );
+    toast({ title: 'Success', description: `${key.replace('_', ' ')} updated` });
+    setFiles(prev => ({ ...prev, [key]: null }));
+    setUploading(null);
+    await refresh();
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Site Assets</h1>
+          <p className="text-gray-600 mt-1">Upload hero image, logo and favicon</p>
+        </div>
+      </div>
+      <div className="grid md:grid-cols-3 gap-6">
+        {ASSETS.map(({ key, label }) => (
+          <Card key={key}>
+            <CardHeader>
+              <CardTitle>{label}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {assets[key] && (
+                key === 'hero_image' ? (
+                  <div className="h-32 bg-cover bg-center rounded" style={{ backgroundImage: `url(${assets[key]})` }} />
+                ) : (
+                  <img src={assets[key]!} alt={label} className="h-24 object-contain mx-auto" />
+                )
+              )}
+              <Input type="file" accept="image/*" onChange={e => handleFileChange(key, e.target.files?.[0] || null)} />
+              <Button onClick={() => uploadAsset(key)} disabled={!files[key] || uploading === key}>
+                {uploading === key ? 'Uploading...' : 'Upload'}
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SiteSettings;

--- a/src/components/homepage/HeroSection.tsx
+++ b/src/components/homepage/HeroSection.tsx
@@ -1,11 +1,13 @@
 
 import { Button } from '@/components/ui/button';
 import { Link } from 'react-router-dom';
+import { useSiteAssets } from '@/hooks/useSiteAssets';
 
 export const HeroSection = () => {
+  const { assets } = useSiteAssets();
   return (
     <section className="relative h-[70vh] bg-cover bg-center bg-no-repeat overflow-hidden" style={{
-      backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url('/lovable-uploads/f00c75e1-9906-4e6e-919a-e1ef524a7e4c.png')`,
+      backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url('${assets.hero_image || '/lovable-uploads/f00c75e1-9906-4e6e-919a-e1ef524a7e4c.png'}')`,
       backgroundPosition: 'center 30%'
     }}>
       <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 lg:py-32 h-full flex items-center">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,10 +4,12 @@ import { Link, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Menu, X } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
+import { useSiteAssets } from '@/hooks/useSiteAssets';
 
 export const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { user, profile, signOut, loading } = useAuth();
+  const { assets } = useSiteAssets();
   const navigate = useNavigate();
 
   const handleSignOut = async () => {
@@ -21,9 +23,9 @@ export const Header = () => {
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
           <Link to="/" className="flex items-center">
-            <img 
-              src="/lovable-uploads/89b8e502-c516-4f94-841b-813b84bedea8.png" 
-              alt="Travel Light Aruba" 
+            <img
+              src={assets.logo || '/lovable-uploads/89b8e502-c516-4f94-841b-813b84bedea8.png'}
+              alt="Travel Light Aruba"
               className="w-[198px] h-[94px] object-contain"
             />
           </Link>

--- a/src/hooks/useSiteAssets.tsx
+++ b/src/hooks/useSiteAssets.tsx
@@ -1,0 +1,60 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+
+interface SiteAssets {
+  hero_image?: string;
+  logo?: string;
+  favicon?: string;
+}
+
+interface SiteAssetsContextType {
+  assets: SiteAssets;
+  refresh: () => Promise<void>;
+}
+
+const SiteAssetsContext = createContext<SiteAssetsContextType | undefined>(undefined);
+
+export const useSiteAssets = () => {
+  const ctx = useContext(SiteAssetsContext);
+  if (!ctx) throw new Error('useSiteAssets must be used within SiteAssetsProvider');
+  return ctx;
+};
+
+export const SiteAssetsProvider = ({ children }: { children: ReactNode }) => {
+  const [assets, setAssets] = useState<SiteAssets>({});
+
+  const fetchAssets = async () => {
+    const { data, error } = await supabase
+      .from('content_images')
+      .select('image_key, file_path')
+      .in('image_key', ['hero_image', 'logo', 'favicon']);
+
+    if (!error && data) {
+      const result: SiteAssets = {};
+      data.forEach(({ image_key, file_path }) => {
+        const { data: url } = supabase.storage
+          .from('site-assets')
+          .getPublicUrl(file_path);
+        (result as any)[image_key] = url.publicUrl;
+      });
+      setAssets(result);
+    }
+  };
+
+  useEffect(() => {
+    fetchAssets();
+  }, []);
+
+  useEffect(() => {
+    if (assets.favicon) {
+      const link = document.querySelector("link[rel*='icon']") as HTMLLinkElement | null;
+      if (link) link.href = assets.favicon;
+    }
+  }, [assets.favicon]);
+
+  return (
+    <SiteAssetsContext.Provider value={{ assets, refresh: fetchAssets }}>
+      {children}
+    </SiteAssetsContext.Provider>
+  );
+};

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -11,6 +11,7 @@ import { ProductManagement } from '@/components/admin/ProductManagement';
 import { BookingAssignment } from '@/components/admin/BookingAssignment';
 import { DriverTasks } from '@/components/admin/DriverTasks';
 import { ReportsDashboard } from '@/components/admin/ReportsDashboard'; // Import ReportsDashboard
+import { SiteSettings } from '@/components/admin/SiteSettings';
 
 const Admin = () => {
   const [activeSection, setActiveSection] = useState('dashboard');
@@ -36,11 +37,7 @@ const Admin = () => {
       case 'tasks':
         return <DriverTasks />;
       case 'settings':
-        return (
-          <div className="text-center py-12">
-            <p className="text-gray-500">Settings coming soon...</p>
-          </div>
-        );
+        return <SiteSettings />;
       default:
         return <AdminDashboard />;
     }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/components/ui/use-toast';
+import { useSiteAssets } from '@/hooks/useSiteAssets';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import LoadingState from '@/components/common/LoadingState';
 import { useEffect } from 'react'; // Import useEffect
@@ -18,6 +19,7 @@ const Login = () => {
   const [isSubmitting, setIsSubmitting] = useState(false); // Renamed loading to isSubmitting for clarity
 
   const auth = useAuth(); // Get the whole auth context
+  const { assets } = useSiteAssets();
   const { toast } = useToast();
   const navigate = useNavigate();
 
@@ -99,9 +101,9 @@ const Login = () => {
           <Card>
             <CardHeader className="text-center">
               <div className="flex justify-center mb-4">
-                <img 
-                  src="/lovable-uploads/89b8e502-c516-4f94-841b-813b84bedea8.png" 
-                  alt="Travel Light Aruba" 
+                <img
+                  src={assets.logo || '/lovable-uploads/89b8e502-c516-4f94-841b-813b84bedea8.png'}
+                  alt="Travel Light Aruba"
                   className="h-16 w-auto"
                 />
               </div>

--- a/supabase/migrations/20250701000000_create_site_assets_bucket.sql
+++ b/supabase/migrations/20250701000000_create_site_assets_bucket.sql
@@ -1,0 +1,14 @@
+-- Create bucket for storing site assets
+insert into storage.buckets (id, name, public)
+values ('site-assets', 'site-assets', true)
+on conflict (id) do nothing;
+
+-- Ensure row level security policies for the bucket
+create policy "Site assets read" on storage.objects
+  for select using (bucket_id = 'site-assets');
+
+create policy "Site assets write" on storage.objects
+  for all using (
+    bucket_id = 'site-assets' and
+    exists (select 1 from public.profiles p where p.id = auth.uid() and p.role in ('Admin','SuperUser'))
+  );


### PR DESCRIPTION
## Summary
- manage hero, logo, and favicon images via new *SiteSettings* admin panel
- fetch site assets from Supabase with `useSiteAssets`
- inject new assets into header, login and hero section
- wrap app in `SiteAssetsProvider`
- create storage bucket migration for `site-assets`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9a9a9cb0832ba7b5244fa0e066e1