### PR TITLE
Implement product image upload and bulk CSV

### DIFF
--- a/supabase/migrations/20250702000000_create_product_images_bucket.sql
+++ b/supabase/migrations/20250702000000_create_product_images_bucket.sql
@@ -1,0 +1,17 @@
+-- Create bucket for storing product images
+insert into storage.buckets (id, name, public)
+values ('product-images', 'product-images', true)
+on conflict (id) do nothing;
+
+-- Row level security policies for product images
+create policy "Product images read" on storage.objects
+  for select using (bucket_id = 'product-images');
+
+create policy "Product images write" on storage.objects
+  for all using (
+    bucket_id = 'product-images'
+    and exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid() and p.role in ('Admin','SuperUser')
+    )
+  );


### PR DESCRIPTION
## Summary
- add Supabase bucket creation for product images
- simplify BulkProductUpload to only require CSV
- enable uploading individual product images in ProductManagement

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea417f850832ba2b8191c2f096528