### PR TITLE
Use featured products for homepage categories

### DIFF
--- a/scripts/seed-equipment.ts
+++ b/scripts/seed-equipment.ts
@@ -109,10 +109,10 @@ const equipmentData: Equipment[] = [
     availability_status: 'Out of Stock'
   },
 
-  // Water Sports
+  // Beach Equipment (Water Sports)
   {
     name: 'Single Kayak',
-    category: 'Water Sports',
+    category: 'Beach Equipment',
     price_per_day: 45,
     description: 'Stable single-person kayak perfect for exploring',
     images: ['https://images.unsplash.com/photo-1506744038136-46273834b3fb'],
@@ -122,7 +122,7 @@ const equipmentData: Equipment[] = [
   },
   {
     name: 'Stand-up Paddleboard',
-    category: 'Water Sports',
+    category: 'Beach Equipment',
     price_per_day: 40,
     description: 'Inflatable SUP board with pump and paddle',
     images: ['https://images.unsplash.com/photo-1544551763-46a013bb70d5'],
@@ -132,7 +132,7 @@ const equipmentData: Equipment[] = [
   },
   {
     name: 'Life Jacket Set (4)',
-    category: 'Water Sports',
+    category: 'Beach Equipment',
     price_per_day: 15,
     description: 'Coast Guard approved life jackets in various sizes',
     images: ['https://images.unsplash.com/photo-1530549387789-4c1017266635'],
@@ -142,7 +142,7 @@ const equipmentData: Equipment[] = [
   },
   {
     name: 'Water Toys Bundle',
-    category: 'Water Sports',
+    category: 'Beach Equipment',
     price_per_day: 28,
     description: 'Fun water toys including floats and games',
     images: ['https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b'],

--- a/src/components/admin/ProductManagement.tsx
+++ b/src/components/admin/ProductManagement.tsx
@@ -32,6 +32,7 @@ const mapSupabaseToProduct = (data: any): Product => {
     image_url: data.image_url ?? '', // Default to empty string if null/undefined
     stock_quantity: data.stock_quantity ?? 0, // Default to 0 if null/undefined
     availability_status: data.availability_status ?? 'Available', // Default to 'Available'
+    featured: data.featured ?? false,
     created_at: data.created_at,
     updated_at: data.updated_at,
   };
@@ -39,7 +40,6 @@ const mapSupabaseToProduct = (data: any): Product => {
 
 const categories = [
   'Beach Equipment',
-  'Water Sports',
   'Camping',
   'Electronics',
   'Transportation',
@@ -64,6 +64,7 @@ export const ProductManagement = () => {
     availability_status: 'Available', // Default to a valid AvailabilityStatus
     stock_quantity: 0,
     image_url: '', // Use image_url directly
+    featured: false,
     image_url_temp: '',
     imageFile: null
   });
@@ -126,6 +127,7 @@ export const ProductManagement = () => {
         availability_status: formState.availability_status as AvailabilityStatus,
         stock_quantity: formState.stock_quantity,
         image_url: imageUrl,
+        featured: formState.featured,
       };
 
       const { data, error } = await supabase
@@ -147,6 +149,7 @@ export const ProductManagement = () => {
         availability_status: 'Available',
         stock_quantity: 0,
         image_url: '',
+        featured: false,
         image_url_temp: '',
         imageFile: null,
       });
@@ -176,6 +179,7 @@ export const ProductManagement = () => {
       stock_quantity: product.stock_quantity,
       image_url: product.image_url || '',
       image_url_temp: product.image_url || '',
+      featured: product.featured ?? false,
       imageFile: null,
     });
     setIsEditDialogOpen(true);
@@ -198,6 +202,7 @@ export const ProductManagement = () => {
         availability_status: formState.availability_status as AvailabilityStatus,
         stock_quantity: formState.stock_quantity,
         image_url: imageUrl,
+        featured: formState.featured,
       };
 
       const { data, error } = await supabase
@@ -382,6 +387,15 @@ export const ProductManagement = () => {
             </SelectContent>
           </Select>
         </div>
+        <div className="flex items-center space-x-2">
+          <input
+            id="featured"
+            type="checkbox"
+            checked={formState.featured}
+            onChange={(e) => setFormState({ ...formState, featured: e.target.checked })}
+          />
+          <Label htmlFor="featured">Featured</Label>
+        </div>
         {/* Removed duplicate Select for Availability Status */}
         <Button onClick={submitHandler} className="w-full">
           {buttonText}
@@ -435,12 +449,12 @@ export const ProductManagement = () => {
         <Dialog open={isCreateDialogOpen} onOpenChange={(isOpen) => {
           setIsCreateDialogOpen(isOpen);
           if (!isOpen) {
-            setFormState({ name: '', description: '', category: '', price_per_day: 0, availability_status: 'Available', stock_quantity: 0, image_url: '', image_url_temp: '', imageFile: null });
+            setFormState({ name: '', description: '', category: '', price_per_day: 0, availability_status: 'Available', stock_quantity: 0, image_url: '', featured: false, image_url_temp: '', imageFile: null });
           }
         }}>
           <DialogTrigger asChild>
             <Button onClick={() => {
-              setFormState({ name: '', description: '', category: '', price_per_day: 0, availability_status: 'Available', stock_quantity: 0, image_url: '', image_url_temp: '', imageFile: null });
+              setFormState({ name: '', description: '', category: '', price_per_day: 0, availability_status: 'Available', stock_quantity: 0, image_url: '', featured: false, image_url_temp: '', imageFile: null });
               setIsCreateDialogOpen(true);
             }}>
               <Plus className="h-4 w-4 mr-2" />

--- a/src/components/homepage/FeaturedCategories.tsx
+++ b/src/components/homepage/FeaturedCategories.tsx
@@ -1,30 +1,36 @@
-
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getFeaturedProducts } from '@/lib/queries/products';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Link } from 'react-router-dom';
 
-const categories = [
-  {
-    title: "Beach Equipment",
-    description: "Umbrellas, chairs, coolers, and water sports gear",
-    image: "https://images.unsplash.com/photo-1500375592092-40eb2168fd21",
-    items: ["Beach Umbrellas", "Beach Chairs", "Coolers", "Snorkel Gear"]
-  },
-  {
-    title: "Baby Equipment",
-    description: "Strollers, car seats, cribs, and safety gear",
-    image: "https://images.unsplash.com/photo-1721322800607-8c38375eef04",
-    items: ["Strollers", "Car Seats", "Baby Cribs", "High Chairs"]
-  },
-  {
-    title: "Water Sports",
-    description: "Kayaks, paddleboards, and water activity gear",
-    image: "https://images.unsplash.com/photo-1506744038136-46273834b3fb",
-    items: ["Kayaks", "Paddleboards", "Life Jackets", "Water Toys"]
-  }
-];
-
 export const FeaturedCategories = () => {
+  const { data: products = [] } = useQuery({
+    queryKey: ['featured-products'],
+    queryFn: getFeaturedProducts,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const categories = useMemo(() => {
+    const groups: Record<string, any[]> = {};
+    for (const product of products) {
+      if (product.category === 'Water Sports') continue; // remove Water Sports
+      if (!groups[product.category]) groups[product.category] = [];
+      groups[product.category].push(product);
+    }
+    return Object.entries(groups).map(([title, items]) => ({
+      title,
+      description: '',
+      image: items[0]?.image_url || '',
+      items: items.slice(0, 4).map(i => i.name),
+    }));
+  }, [products]);
+
+  if (categories.length === 0) {
+    return null;
+  }
+
   return (
     <section className="py-16 bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -41,15 +47,17 @@ export const FeaturedCategories = () => {
           {categories.map((category, index) => (
             <Card key={index} className="overflow-hidden hover:shadow-lg transition-shadow">
               <div className="aspect-video relative overflow-hidden">
-                <img 
-                  src={category.image} 
-                  alt={category.title}
-                  className="w-full h-full object-cover hover:scale-105 transition-transform duration-300"
-                />
+                {category.image && (
+                  <img
+                    src={category.image}
+                    alt={category.title}
+                    className="w-full h-full object-cover hover:scale-105 transition-transform duration-300"
+                  />
+                )}
               </div>
               <CardHeader>
                 <CardTitle className="text-xl">{category.title}</CardTitle>
-                <p className="text-gray-600">{category.description}</p>
+                {category.description && <p className="text-gray-600">{category.description}</p>}
               </CardHeader>
               <CardContent>
                 <ul className="space-y-2 mb-4">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -37,7 +37,6 @@ export const Footer = () => {
             <ul className="space-y-2 text-gray-400">
               <li><Link to="/equipment?category=beach" className="hover:text-white transition-colors">Beach Equipment</Link></li>
               <li><Link to="/equipment?category=baby" className="hover:text-white transition-colors">Baby Equipment</Link></li>
-              <li><Link to="/equipment?category=water" className="hover:text-white transition-colors">Water Sports</Link></li>
             </ul>
           </div>
 

--- a/src/data/mockEquipment.ts
+++ b/src/data/mockEquipment.ts
@@ -95,11 +95,11 @@ export const mockEquipment: Equipment[] = [
     features: ['Height Adjustable', 'Safety Harness', 'Easy Clean', 'Foldable']
   },
 
-  // Water Sports
+  // Beach Equipment (Water Sports)
   {
     id: '9',
     name: 'Single Kayak',
-    category: 'Water Sports',
+    category: 'Beach Equipment',
     price: 45,
     image: 'https://images.unsplash.com/photo-1506744038136-46273834b3fb',
     description: 'Stable single-person kayak perfect for exploring',
@@ -109,7 +109,7 @@ export const mockEquipment: Equipment[] = [
   {
     id: '10',
     name: 'Stand-up Paddleboard',
-    category: 'Water Sports',
+    category: 'Beach Equipment',
     price: 40,
     image: 'https://images.unsplash.com/photo-1544551763-46a013bb70d5',
     description: 'Inflatable SUP board with pump and paddle',
@@ -119,7 +119,7 @@ export const mockEquipment: Equipment[] = [
   {
     id: '11',
     name: 'Life Jacket Set (4)',
-    category: 'Water Sports',
+    category: 'Beach Equipment',
     price: 15,
     image: 'https://images.unsplash.com/photo-1530549387789-4c1017266635',
     description: 'Coast Guard approved life jackets in various sizes',
@@ -129,7 +129,7 @@ export const mockEquipment: Equipment[] = [
   {
     id: '12',
     name: 'Water Toys Bundle',
-    category: 'Water Sports',
+    category: 'Beach Equipment',
     price: 28,
     image: 'https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b',
     description: 'Fun water toys including floats and games',

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -208,6 +208,7 @@ export type Database = {
           image_url: string | null
           name: string
           price_per_day: number
+          featured: boolean
           availability_status: string | null
           stock_quantity: number
           updated_at: string
@@ -222,6 +223,7 @@ export type Database = {
           image_url?: string | null
           name: string
           price_per_day?: number
+          featured?: boolean
           availability_status?: string | null
           stock_quantity?: number
           updated_at?: string
@@ -236,6 +238,7 @@ export type Database = {
           image_url?: string | null
           name?: string
           price_per_day?: number
+          featured?: boolean
           availability_status?: string | null
           stock_quantity?: number
           updated_at?: string

--- a/src/lib/queries/products.ts
+++ b/src/lib/queries/products.ts
@@ -9,3 +9,14 @@ export const getProducts = async () => {
   if (error) throw error;
   return data || [];
 };
+
+export const getFeaturedProducts = async () => {
+  const { data, error } = await supabase
+    .from('products')
+    .select('*')
+    .eq('featured', true)
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+  return data || [];
+};

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -13,6 +13,7 @@ export interface Product {
   image_url?: string | null | undefined;
   stock_quantity: number; // Made non-optional
   availability_status?: AvailabilityStatus; // Uncommented and made optional
+  featured?: boolean;
   created_at?: string; // ISO 8601 date string
   updated_at?: string; // ISO 8601 date string
 }

--- a/supabase/migrations/20250703000000_add_featured_to_products.sql
+++ b/supabase/migrations/20250703000000_add_featured_to_products.sql
@@ -1,0 +1,3 @@
+-- Add featured column to products table
+ALTER TABLE public.products
+  ADD COLUMN IF NOT EXISTS featured boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- add `featured` field to products schema and types
- support featured flag in Product Management UI
- fetch featured products on the homepage
- remove references to the `Water Sports` category

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb122de54832b82b51f4fb0b22d48