### PR TITLE
Switch API calls to equipment table

### DIFF
--- a/scripts/seed-equipment.ts
+++ b/scripts/seed-equipment.ts
@@ -157,7 +157,7 @@ async function seedEquipment() {
 
   // Check if equipment already exists
   const { data: existingEquipment, error: checkError } = await supabaseAdmin
-    .from('products')
+    .from('equipment')
     .select('name')
     .limit(1);
 
@@ -173,7 +173,7 @@ async function seedEquipment() {
 
   // Insert equipment data
   const { error: insertError } = await supabaseAdmin
-    .from('products')
+    .from('equipment')
     .insert(equipmentData);
 
   if (insertError) {

--- a/src/components/admin/BulkProductUpload.tsx
+++ b/src/components/admin/BulkProductUpload.tsx
@@ -53,7 +53,7 @@ const products = parsedRows.map(row => ({
 }));
 
 if (products.length > 0) {
-  const { error } = await supabase.from('products').insert(products);
+  const { error } = await supabase.from('equipment').insert(products);
   if (error) throw error;
 }
 

--- a/src/components/admin/ProductManagement.tsx
+++ b/src/components/admin/ProductManagement.tsx
@@ -92,7 +92,7 @@ export const ProductManagement = () => {
   const fetchProducts = async () => {
     try {
       const { data, error } = await supabase
-        .from('products')
+        .from('equipment')
         .select('*')
         .order('created_at', { ascending: false });
 
@@ -131,7 +131,7 @@ export const ProductManagement = () => {
       };
 
       const { data, error } = await supabase
-        .from('products')
+        .from('equipment')
         .insert([productDataToSave])
         .select()
         .single(); 
@@ -206,7 +206,7 @@ export const ProductManagement = () => {
       };
 
       const { data, error } = await supabase
-        .from('products')
+        .from('equipment')
         .update(productDataToUpdate)
         .eq('id', editingProduct.id)
         .select()
@@ -237,7 +237,7 @@ export const ProductManagement = () => {
     if (!productToDelete) return;
     try {
       const { error } = await supabase
-        .from('products')
+        .from('equipment')
         .delete()
         .eq('id', productToDelete.id);
 
@@ -263,7 +263,7 @@ export const ProductManagement = () => {
     const newStatus: AvailabilityStatus = product.availability_status === 'Available' ? 'Out of Stock' : 'Available';
     try {
       const { data, error } = await supabase
-        .from('products')
+        .from('equipment')
         .update({ availability_status: newStatus } as any) // Cast to any to bypass incorrect type inference
         .eq('id', product.id)
         .select()

--- a/src/components/admin/ReportsDashboard.tsx
+++ b/src/components/admin/ReportsDashboard.tsx
@@ -244,7 +244,7 @@ export const ReportsDashboard: React.FC = () => {
       }
 
       const { data: productsData, error: productsError } = await supabase
-        .from('products')
+        .from('equipment')
         .select('*'); // Select all columns including stock_quantity
       if (productsError) throw productsError;
       

--- a/src/hooks/useBooking.ts
+++ b/src/hooks/useBooking.ts
@@ -45,7 +45,7 @@ const useBooking = () => {
       };
 
       const { data, error } = await supabase
-        .from('products')
+        .from('equipment')
         .select('id, name, description, price_per_day, category, images, availability, created_at, updated_at');
 
       if (error) {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -197,7 +197,7 @@ export type Database = {
         }
         Relationships: []
       }
-      products: {
+      equipment: {
         Row: {
           availability: boolean
           category: string

--- a/src/lib/queries/products.ts
+++ b/src/lib/queries/products.ts
@@ -2,7 +2,7 @@ import { supabase } from '@/integrations/supabase/client';
 
 export const getProducts = async () => {
   const { data, error } = await supabase
-    .from('products')
+    .from('equipment')
     .select('*')
     .order('created_at', { ascending: false });
 
@@ -12,7 +12,7 @@ export const getProducts = async () => {
 
 export const getFeaturedProducts = async () => {
   const { data, error } = await supabase
-    .from('products')
+    .from('equipment')
     .select('*')
     .eq('featured', true)
     .order('created_at', { ascending: false });


### PR DESCRIPTION
## Summary
- fetch rental items from `equipment` table instead of `products`
- update admin utilities to insert/update/delete equipment
- rename generated Supabase types to use `equipment`
- seed script now targets `equipment` table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ebda78628832bb92fb9aa73b93f60