### PR TITLE
Add equipment table migration

### DIFF
--- a/supabase/migrations/20250704000000_create_equipment_table.sql
+++ b/supabase/migrations/20250704000000_create_equipment_table.sql
@@ -1,0 +1,16 @@
+-- Create equipment table for bulk CSV uploads
+CREATE TABLE public.equipment (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  description text,
+  price_per_day numeric NOT NULL DEFAULT 0,
+  category text NOT NULL,
+  images text[] DEFAULT '{}',
+  stock_quantity integer NOT NULL DEFAULT 0,
+  availability boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  image_url text,
+  availability_status text DEFAULT 'Available',
+  featured boolean NOT NULL DEFAULT false
+);


### PR DESCRIPTION
## Summary
- add SQL migration to create `equipment` table for bulk uploads

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ecd2d1400832b9c1c18091920d2b4