### PR TITLE
Fix fallback images to avoid 404s

### DIFF
--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -43,7 +43,7 @@ export const AdminSidebar = ({ activeSection, onSectionChange }: AdminSidebarPro
       <div className="p-6">
         <div className="flex items-center mb-4">
           <img
-            src={assets.logo || '/lovable-uploads/89b8e502-c516-4f94-841b-813b84bedea8.png'}
+            src={assets.logo || '/placeholder.svg'}
             alt="Travel Light Aruba"
             className="h-8 w-auto mr-3"
           />

--- a/src/components/homepage/HeroSection.tsx
+++ b/src/components/homepage/HeroSection.tsx
@@ -7,7 +7,7 @@ export const HeroSection = () => {
   const { assets } = useSiteAssets();
   return (
     <section className="relative h-[70vh] bg-cover bg-center bg-no-repeat overflow-hidden" style={{
-      backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url('${assets.hero_image || '/lovable-uploads/f00c75e1-9906-4e6e-919a-e1ef524a7e4c.png'}')`,
+      backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url('${assets.hero_image || '/placeholder.svg'}')`,
       backgroundPosition: 'center 30%'
     }}>
       <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 lg:py-32 h-full flex items-center">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -24,7 +24,7 @@ export const Header = () => {
           {/* Logo */}
           <Link to="/" className="flex items-center">
             <img
-              src={assets.logo || '/lovable-uploads/89b8e502-c516-4f94-841b-813b84bedea8.png'}
+              src={assets.logo || '/placeholder.svg'}
               alt="Travel Light Aruba"
               className="w-[198px] h-[94px] object-contain"
             />

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -102,7 +102,7 @@ const Login = () => {
             <CardHeader className="text-center">
               <div className="flex justify-center mb-4">
                 <img
-                  src={assets.logo || '/lovable-uploads/89b8e502-c516-4f94-841b-813b84bedea8.png'}
+                  src={assets.logo || '/placeholder.svg'}
                   alt="Travel Light Aruba"
                   className="h-16 w-auto"
                 />


### PR DESCRIPTION
## Summary
- use local placeholder asset when no hero image is configured
- update logo fallbacks to placeholder

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ecfb0d96c832b8577098efddec26c