### PR TITLE
Add homepage highlight selection

### DIFF
--- a/src/components/admin/HighlightProductsSettings.tsx
+++ b/src/components/admin/HighlightProductsSettings.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+
+interface Product {
+  id: string;
+  name: string;
+  image_url: string | null;
+  featured: boolean;
+}
+
+export const HighlightProductsSettings = () => {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [saving, setSaving] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('equipment')
+        .select('id,name,image_url,featured')
+        .order('name');
+      if (!error && data) {
+        setProducts(data as Product[]);
+        setSelected(data.filter((p) => p.featured).map((p) => p.id));
+      }
+    };
+    load();
+  }, []);
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      if (prev.includes(id)) {
+        return prev.filter((p) => p !== id);
+      }
+      if (prev.length >= 3) {
+        toast({
+          title: 'Limit reached',
+          description: 'You can only select up to 3 products',
+          variant: 'destructive',
+        });
+        return prev;
+      }
+      return [...prev, id];
+    });
+  };
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      await supabase.from('equipment').update({ featured: false }).eq('featured', true);
+      if (selected.length > 0) {
+        await supabase.from('equipment').update({ featured: true }).in('id', selected);
+      }
+      toast({ title: 'Success', description: 'Highlights updated' });
+    } catch (err) {
+      toast({ title: 'Error', description: 'Failed to save highlights', variant: 'destructive' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Homepage Highlight Products</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-gray-500 mb-4">
+          Select up to 3 products to display under "Popular Equipment" on the home page.
+        </p>
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {products.map((product) => (
+            <label
+              key={product.id}
+              className={`flex items-center gap-2 border rounded p-2 cursor-pointer ${selected.includes(product.id) ? 'bg-blue-50 border-blue-300' : ''}`}
+            >
+              <Checkbox
+                checked={selected.includes(product.id)}
+                onCheckedChange={() => toggle(product.id)}
+              />
+              {product.image_url && (
+                <img
+                  src={product.image_url}
+                  alt={product.name}
+                  className="w-12 h-12 object-cover rounded"
+                />
+              )}
+              <span className="font-medium">{product.name}</span>
+            </label>
+          ))}
+        </div>
+        <Button onClick={save} disabled={saving} className="mt-4">
+          {saving ? 'Saving...' : 'Save'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default HighlightProductsSettings;

--- a/src/components/admin/SiteSettings.tsx
+++ b/src/components/admin/SiteSettings.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { HighlightProductsSettings } from './HighlightProductsSettings';
 import { useSiteAssets } from '@/hooks/useSiteAssets';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
@@ -122,6 +123,8 @@ export const SiteSettings = () => {
           </Button>
         </CardContent>
       </Card>
+
+      <HighlightProductsSettings />
     </div>
   );
 };

--- a/src/components/homepage/FeaturedProducts.tsx
+++ b/src/components/homepage/FeaturedProducts.tsx
@@ -1,0 +1,64 @@
+import { useQuery } from '@tanstack/react-query';
+import { getFeaturedProducts } from '@/lib/queries/products';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Link } from 'react-router-dom';
+
+export const FeaturedProducts = () => {
+  const { data: products = [] } = useQuery({
+    queryKey: ['featured-products'],
+    queryFn: getFeaturedProducts,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (products.length === 0) return null;
+
+  return (
+    <section className="py-16 bg-gray-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            Popular Equipment
+          </h2>
+          <p className="text-xl text-gray-600 max-w-2xl mx-auto">
+            Discover our most popular rental items
+          </p>
+        </div>
+        <div className="grid md:grid-cols-3 gap-8">
+          {products.slice(0, 3).map((product) => (
+            <Card
+              key={product.id}
+              className="overflow-hidden hover:shadow-lg transition-shadow"
+            >
+              {product.image_url && (
+                <img
+                  src={product.image_url}
+                  alt={product.name}
+                  className="w-full h-48 object-cover"
+                />
+              )}
+              <CardHeader>
+                <CardTitle className="text-xl">{product.name}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {product.description && (
+                  <p className="text-gray-600 mb-2 line-clamp-3">
+                    {product.description}
+                  </p>
+                )}
+                <div className="text-lg font-bold mb-4">
+                  ${'{'}Number(product.price_per_day).toFixed(2){'}'}/day
+                </div>
+                <Link to="/equipment" className="block">
+                  <Button className="w-full">View All</Button>
+                </Link>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default FeaturedProducts;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,7 +2,7 @@
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
 import { HeroSection } from '@/components/homepage/HeroSection';
-import { FeaturedCategories } from '@/components/homepage/FeaturedCategories';
+import { FeaturedProducts } from '@/components/homepage/FeaturedProducts';
 import { HowItWorks } from '@/components/homepage/HowItWorks';
 
 const Index = () => {
@@ -11,7 +11,7 @@ const Index = () => {
       <Header />
       <main className="flex-1">
         <HeroSection />
-        <FeaturedCategories />
+        <FeaturedProducts />
         <HowItWorks />
       </main>
       <Footer />


### PR DESCRIPTION
## Summary
- allow admins to pick highlighted products under Settings
- display up to three highlighted products on the home page

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm test` *(fails: Supabase URL required)*

------
https://chatgpt.com/codex/tasks/task_e_68626cd97c64832b815205d1022aa1c7