### PR TITLE
Hide booking and sign-up options

### DIFF
--- a/src/components/equipment/EquipmentCard.tsx
+++ b/src/components/equipment/EquipmentCard.tsx
@@ -95,9 +95,10 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
       </CardContent>
       
       <CardFooter>
-        <Link to="/book" className="w-full">
-          <Button 
-            className="w-full" 
+        {/* Keep booking button in code but hide until feature launch */}
+        <Link to="/book" className="w-full hidden" hidden>
+          <Button
+            className="w-full"
             disabled={equipment.availability === 'unavailable'}
           >
             {'Book Now'}

--- a/src/components/layout/Footer.test.tsx
+++ b/src/components/layout/Footer.test.tsx
@@ -39,6 +39,7 @@ describe('Footer Component', () => {
     );
     // Use exact match for the main "Equipment" link to avoid multiple matches
     expect(screen.getByRole('link', { name: /^Equipment$/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Book Now/i })).toBeInTheDocument();
+    // Book Now link is hidden; ensure it is not rendered
+    expect(screen.queryByRole('link', { name: /Book Now/i })).not.toBeInTheDocument();
   });
 });

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -25,7 +25,10 @@ export const Footer = () => {
             <h3 className="text-lg font-semibold mb-4">Quick Links</h3>
             <ul className="space-y-2 text-gray-400">
               <li><Link to="/equipment" className="hover:text-white transition-colors">Equipment</Link></li>
-              <li><Link to="/book" className="hover:text-white transition-colors">Book Now</Link></li>
+              {/* Temporarily hide booking link until feature is available */}
+              <li hidden className="hidden">
+                <Link to="/book" className="hover:text-white transition-colors">Book Now</Link>
+              </li>
               <li><Link to="/about" className="hover:text-white transition-colors">About Us</Link></li>
               <li><Link to="/contact" className="hover:text-white transition-colors">Contact</Link></li>
             </ul>

--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -40,12 +40,11 @@ describe('Header Component', () => {
     expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute('href', '/contact');
   });
 
-  it('renders CTA buttons for Book Now and Login', () => {
+  it('renders CTA button for Login only (Book Now hidden)', () => {
     renderHeader();
     // The buttons are within Link components, so we find the link by its role and name (from button text)
-    const bookNowLink = screen.getByRole('link', { name: /book now/i });
-    expect(bookNowLink).toBeInTheDocument();
-    expect(bookNowLink).toHaveAttribute('href', '/book');
+    // Book Now should not be rendered while booking is disabled
+    expect(screen.queryByRole('link', { name: /book now/i })).not.toBeInTheDocument();
 
     const logoutBtn = screen.getByRole('button', { name: /logout/i });
     expect(logoutBtn).toBeInTheDocument();

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -63,7 +63,8 @@ export const Header = () => {
             ) : user && profile ? (
               <>
                 {profile.role === 'Booker' && (
-                  <Button asChild>
+                  // Hide Book Now button until booking is enabled
+                  <Button asChild className="hidden" hidden>
                     <Link to="/book">Book Now</Link>
                   </Button>
                 )}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -70,7 +70,8 @@ const MobileNav = () => {
             ) : user && profile ? (
               <div className="space-y-2">
                 {profile.role === 'Booker' && (
-                  <Button asChild className="w-full" onClick={() => setIsOpen(false)}>
+                  // Hide Book Now option for now
+                  <Button asChild className="w-full hidden" hidden onClick={() => setIsOpen(false)}>
                     <Link to="/book">Book Now</Link>
                   </Button>
                 )}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -138,7 +138,8 @@ const Login = () => {
                 </Link>
               </div>
 
-              <div className="mt-4 text-center text-sm">
+              {/* Sign-up link hidden until registration is enabled */}
+              <div className="mt-4 text-center text-sm hidden" hidden>
                 Don't have an account?{' '}
                 <Link to="/signup" className="font-medium text-blue-600 hover:underline">
                   Sign up


### PR DESCRIPTION
## Summary
- hide Book Now links in footer, header, mobile nav and equipment card
- hide sign-up link on login page
- update tests to check that Book Now link is absent

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68626e3d5514832bb3c81fb7091e4351