### PR TITLE
Add contact page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { SiteAssetsProvider } from "@/hooks/useSiteAssets";
 import Index from "./pages/Index";
 import Equipment from "./pages/Equipment";
 import Book from "./pages/Book";
+import Contact from "./pages/Contact";
 import Admin from "./pages/Admin";
 import Login from "./pages/Login";
 import DriverDashboard from "./pages/DriverDashboard"; // Import DriverDashboard
@@ -59,7 +60,9 @@ const App = () => (
               {/* Booker role can access their dashboard. Admin/SuperUser might also need access for impersonation or support. */}
               <Route path="/booker" element={<BookerDashboard />} />
             </Route>
-            
+
+            <Route path="/contact" element={<Contact />} />
+
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,0 +1,27 @@
+import { Header } from '@/components/layout/Header';
+import { Footer } from '@/components/layout/Footer';
+
+const Contact = () => {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 bg-gray-50">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+          <h1 className="text-3xl font-bold text-gray-900 mb-6">Contact Us</h1>
+          <p className="text-lg text-gray-700 mb-4">
+            We'd love to hear from you. Reach out using the information below.
+          </p>
+          <div className="space-y-2 text-gray-800">
+            <p>To make a reservation for rentals, please send us an e-mail to:</p>
+            <p>
+              📧 <a href="mailto:info@travelightaruba.com" className="text-blue-600 hover:underline">info@travelightaruba.com</a>
+            </p>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Contact;


### PR DESCRIPTION
## Summary
- add new `Contact` page using same phone/email as footer
- register `/contact` route
- remove phone from the Contact page and adjust the instructions text

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68626ee744e8832ba7780250ff50c2d0