### PR TITLE
Fix price formatting on homepage

### DIFF
--- a/src/components/homepage/FeaturedProducts.tsx
+++ b/src/components/homepage/FeaturedProducts.tsx
@@ -47,7 +47,8 @@ export const FeaturedProducts = () => {
                   </p>
                 )}
                 <div className="text-lg font-bold mb-4">
-                  ${'{'}Number(product.price_per_day).toFixed(2){'}'}/day
+                  {"$"}
+                  {Number(product.price_per_day).toFixed(2)}/day
                 </div>
                 <Link to="/equipment" className="block">
                   <Button className="w-full">View All</Button>


### PR DESCRIPTION
## Summary
- show computed price per day instead of raw string on homepage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68627644d158832bbd8bf8b7e6b2ef91