### PR TITLE
Fix Cloudflare env variable handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ VITE_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # Cloudflare Images Configuration
 VITE_CLOUDFLARE_ACCOUNT_ID=your-cloudflare-account-id
 VITE_CLOUDFLARE_API_TOKEN=your-cloudflare-api-token
+# These are used by the Supabase Edge Function. They can mirror the Vite vars.
+CLOUDFLARE_ACCOUNT_ID=${VITE_CLOUDFLARE_ACCOUNT_ID}
+CLOUDFLARE_API_TOKEN=${VITE_CLOUDFLARE_API_TOKEN}

--- a/CLOUDFLARE_SETUP.md
+++ b/CLOUDFLARE_SETUP.md
@@ -36,6 +36,9 @@ This guide explains how to set up and use the Cloudflare Images integration in y
    ```env
    VITE_CLOUDFLARE_ACCOUNT_ID=your-actual-account-id
    VITE_CLOUDFLARE_API_TOKEN=your-actual-api-token
+   # Edge function variables (can reuse the above values)
+   CLOUDFLARE_ACCOUNT_ID=$VITE_CLOUDFLARE_ACCOUNT_ID
+   CLOUDFLARE_API_TOKEN=$VITE_CLOUDFLARE_API_TOKEN
    ```
 
 ### 3. Upload Images to Cloudflare

--- a/supabase/functions/cloudflare-images-proxy/index.ts
+++ b/supabase/functions/cloudflare-images-proxy/index.ts
@@ -14,9 +14,14 @@ Deno.serve(async (req: Request) => {
     const per_page = url.searchParams.get('per_page') || '50';
     const search = url.searchParams.get('search') || '';
 
-    // Get Cloudflare credentials from environment
-    const accountId = Deno.env.get('CLOUDFLARE_ACCOUNT_ID');
-    const apiToken = Deno.env.get('CLOUDFLARE_API_TOKEN');
+  // Get Cloudflare credentials from environment
+  // Support both plain and Vite-prefixed variable names for flexibility
+  const accountId =
+    Deno.env.get('CLOUDFLARE_ACCOUNT_ID') ||
+    Deno.env.get('VITE_CLOUDFLARE_ACCOUNT_ID');
+  const apiToken =
+    Deno.env.get('CLOUDFLARE_API_TOKEN') ||
+    Deno.env.get('VITE_CLOUDFLARE_API_TOKEN');
 
     if (!accountId || !apiToken) {
       return new Response(


### PR DESCRIPTION
## Summary
- allow the Cloudflare edge function to read `VITE_` prefixed environment variables
- add example variable names for edge functions in `.env.example`
- update Cloudflare setup docs with edge variable instructions

## Testing
- `npm run lint` *(fails: unexpected any, parsing errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862833b60d8832ba798297a520a8d8a