### PR TITLE
Add settings for subgroup order

### DIFF
--- a/src/components/admin/SiteSettings.tsx
+++ b/src/components/admin/SiteSettings.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { HighlightProductsSettings } from './HighlightProductsSettings';
+import { SubGroupOrderSettings } from './SubGroupOrderSettings';
 import { useSiteAssets } from '@/hooks/useSiteAssets';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
@@ -125,6 +126,7 @@ export const SiteSettings = () => {
       </Card>
 
       <HighlightProductsSettings />
+      <SubGroupOrderSettings />
     </div>
   );
 };

--- a/src/components/admin/SubGroupOrderSettings.tsx
+++ b/src/components/admin/SubGroupOrderSettings.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState, useMemo } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+
+interface SubCategory {
+  id: string;
+  name: string;
+  sort_order: number | null;
+  equipment_category: {
+    id: string;
+    name: string;
+    sort_order: number | null;
+  } | null;
+}
+
+export const SubGroupOrderSettings = () => {
+  const [subCategories, setSubCategories] = useState<SubCategory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('equipment_sub_category')
+        .select('id,name,sort_order,equipment_category(id,name,sort_order)')
+        .order('sort_order', { ascending: true, nullsFirst: false });
+      if (!error && data) {
+        setSubCategories(data as SubCategory[]);
+      } else {
+        toast({ title: 'Error', description: 'Failed to load subgroups', variant: 'destructive' });
+      }
+      setLoading(false);
+    };
+    load();
+  }, [toast]);
+
+  const grouped = useMemo(() => {
+    const map: Record<string, { sort_order: number; items: SubCategory[] }> = {};
+    subCategories.forEach(sc => {
+      const catName = sc.equipment_category?.name || 'Uncategorized';
+      const catOrder = sc.equipment_category?.sort_order ?? 0;
+      if (!map[catName]) {
+        map[catName] = { sort_order: catOrder, items: [] };
+      }
+      map[catName].items.push(sc);
+    });
+    const sortedCats = Object.entries(map).sort((a, b) => a[1].sort_order - b[1].sort_order);
+    const result: [string, SubCategory[]][] = sortedCats.map(([name, data]) => {
+      const sortedSubs = data.items.sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
+      return [name, sortedSubs];
+    });
+    return result;
+  }, [subCategories]);
+
+  const handleChange = (id: string, value: number) => {
+    setSubCategories(prev => prev.map(sc => sc.id === id ? { ...sc, sort_order: value } : sc));
+  };
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      await Promise.all(
+        subCategories.map(sc =>
+          supabase.from('equipment_sub_category').update({ sort_order: sc.sort_order ?? 0 }).eq('id', sc.id)
+        )
+      );
+      toast({ title: 'Success', description: 'Subgroup order updated' });
+    } catch (err) {
+      toast({ title: 'Error', description: 'Failed to save order', variant: 'destructive' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="py-4">Loading...</div>;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Subgroup Display Order</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {grouped.map(([catName, subs]) => (
+          <div key={catName} className="mb-6">
+            <h4 className="font-semibold mb-2">{catName}</h4>
+            {subs.map(sc => (
+              <div key={sc.id} className="flex items-center gap-2 mb-2">
+                <span className="flex-1">{sc.name}</span>
+                <Input
+                  type="number"
+                  value={sc.sort_order ?? 0}
+                  onChange={e => handleChange(sc.id, Number(e.target.value))}
+                  className="w-24"
+                />
+              </div>
+            ))}
+          </div>
+        ))}
+        <Button onClick={save} disabled={saving}>
+          {saving ? 'Saving...' : 'Save Order'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default SubGroupOrderSettings;

--- a/src/pages/Equipment.tsx
+++ b/src/pages/Equipment.tsx
@@ -2,10 +2,16 @@ import { useState, useMemo, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { EquipmentCard } from '@/components/equipment/EquipmentCard';
 import { EquipmentFilters } from '@/components/equipment/EquipmentFilters';
-import type { Equipment as EquipmentType } from '@/data/mockEquipment';
+import type { Equipment as BaseEquipment } from '@/data/mockEquipment';
 import { getProducts } from '@/lib/queries/products';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
+
+interface EquipmentItem extends BaseEquipment {
+  sub_category?: string;
+  category_sort_order: number;
+  sub_category_sort_order: number;
+}
 
 const Equipment = () => {
   const [filters, setFilters] = useState({
@@ -21,7 +27,7 @@ const Equipment = () => {
     staleTime: 5 * 60 * 1000,
   });
 
-  const equipmentData: EquipmentType[] = useMemo(() => {
+  const equipmentData: EquipmentItem[] = useMemo(() => {
     return products.map((p: any) => {
       const stock = p.stock_quantity ?? 0;
       let availability: 'available' | 'limited' | 'unavailable';
@@ -39,7 +45,9 @@ const Equipment = () => {
         description: p.description || '',
         availability,
         features: [],
-      } as EquipmentType;
+        category_sort_order: p.equipment_category?.sort_order ?? 0,
+        sub_category_sort_order: p.equipment_sub_category?.sort_order ?? 0,
+      } as EquipmentItem;
     });
   }, [products]);
 
@@ -87,29 +95,29 @@ const Equipment = () => {
   }, [filters, equipmentData]);
 
   const groupedEquipment = useMemo(() => {
-    const grouped = filteredEquipment.reduce((acc, item) => {
+    const map: Record<string, { order: number; subs: Record<string, { order: number; items: EquipmentItem[] }> }> = {};
+    filteredEquipment.forEach(item => {
       const category = item.category || 'Uncategorized';
-      const subCategory = (item as any).sub_category || 'General';
-      if (!acc[category]) {
-        acc[category] = {};
+      const subCategory = item.sub_category || 'General';
+      if (!map[category]) {
+        map[category] = { order: item.category_sort_order, subs: {} };
       }
-      if (!acc[category][subCategory]) {
-        acc[category][subCategory] = [];
+      if (!map[category].subs[subCategory]) {
+        map[category].subs[subCategory] = { order: item.sub_category_sort_order, items: [] };
       }
-      acc[category][subCategory].push(item);
-      return acc;
-    }, {} as Record<string, Record<string, EquipmentType[]>>);
+      map[category].subs[subCategory].items.push(item);
+    });
 
-    // Sort subcategories within each category
-    for (const category in grouped) {
-      const subCategories = Object.entries(grouped[category]);
-      // This is a bit of a hack since we don't have the sort order here.
-      // A better solution would be to fetch the sort order along with the products.
-      subCategories.sort(([a], [b]) => a.localeCompare(b));
-      grouped[category] = Object.fromEntries(subCategories);
-    }
-
-    return grouped;
+    const sortedCategories = Object.entries(map).sort((a, b) => a[1].order - b[1].order);
+    const result: Record<string, Record<string, EquipmentItem[]>> = {};
+    sortedCategories.forEach(([catName, catData]) => {
+      const sortedSubs = Object.entries(catData.subs).sort((a, b) => a[1].order - b[1].order);
+      result[catName] = {};
+      sortedSubs.forEach(([subName, subData]) => {
+        result[catName][subName] = subData.items;
+      });
+    });
+    return result;
   }, [filteredEquipment]);
 
   if (isLoading) {


### PR DESCRIPTION
## Summary
- support editing equipment sub-category order in admin settings
- display equipment sub-categories according to order on /equipment page

## Testing
- `npm test`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_686289806ce4832b84d92956cab40c2e