### PR TITLE
Add RichTextEditor with HTML sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "react-leaflet": "^4.2.1",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
+    "react-quill": "^2.0.0",
+    "dompurify": "^3.0.8",
     "recharts": "^2.12.7",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",

--- a/src/components/admin/ProductManagement.tsx
+++ b/src/components/admin/ProductManagement.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
+import { RichTextEditor } from '@/components/ui/rich-text-editor';
+import DOMPurify from 'dompurify';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Plus, Cloud } from 'lucide-react';
@@ -106,7 +107,7 @@ export const ProductManagement = () => {
 
     const dataToSave = {
       name: formState.name,
-      description: formState.description,
+      description: DOMPurify.sanitize(formState.description),
       price_per_day: formState.price_per_day,
       stock_quantity: formState.stock_quantity,
       availability_status: formState.availability_status,
@@ -166,7 +167,7 @@ export const ProductManagement = () => {
       </DialogHeader>
       <div className="space-y-4 py-4">
         <Input placeholder="Product Name" value={formState.name} onChange={e => setFormState({ ...formState, name: e.target.value })} />
-        <Textarea placeholder="Description" value={formState.description} onChange={e => setFormState({ ...formState, description: e.target.value })} />
+        <RichTextEditor value={formState.description} onChange={html => setFormState({ ...formState, description: html })} />
         <Select value={formState.category_id} onValueChange={value => setFormState({ ...formState, category_id: value, sub_category_id: '' })}>
           <SelectTrigger><SelectValue placeholder="Select category" /></SelectTrigger>
           <SelectContent>{categories.map(c => <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>)}</SelectContent>

--- a/src/components/ui/rich-text-editor.tsx
+++ b/src/components/ui/rich-text-editor.tsx
@@ -1,0 +1,21 @@
+import ReactQuill from 'react-quill'
+import 'react-quill/dist/quill.snow.css'
+import { cn } from '@/lib/utils'
+
+interface RichTextEditorProps {
+  value: string
+  onChange: (value: string) => void
+  className?: string
+}
+
+const modules = {
+  toolbar: [
+    ['bold', 'italic', 'underline'],
+  ],
+}
+
+export const RichTextEditor = ({ value, onChange, className }: RichTextEditorProps) => (
+  <ReactQuill theme="snow" value={value} onChange={onChange} modules={modules} className={cn('min-h-[120px]', className)} />
+)
+
+export default RichTextEditor


### PR DESCRIPTION
## Summary
- add a RichTextEditor component using react-quill
- swap Textarea for RichTextEditor in ProductManagement
- sanitize HTML with DOMPurify before saving
- include new dependencies react-quill and dompurify

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68628c434cfc832bb1429ed4bd76f3e2