### PR TITLE
Add weekly pricing display

### DIFF
--- a/src/components/admin/ProductCard.tsx
+++ b/src/components/admin/ProductCard.tsx
@@ -47,7 +47,7 @@ export const ProductCard = ({ product, onEdit, onDelete, onToggleAvailability }:
           <div className="text-sm text-gray-500">Stock: {product.stock_quantity}</div>
           <div className="text-lg font-bold text-green-600">
             {"$"}
-            {Number(product.price_per_day).toFixed(2)}/day
+            {Number(product.price_per_day).toFixed(2)}/day | {Number(product.price_per_day * 5).toFixed(2)}/week
           </div>
         </div>
         <div className="flex gap-2 pt-2 border-t mt-auto">

--- a/src/components/booking/EquipmentSelection.tsx
+++ b/src/components/booking/EquipmentSelection.tsx
@@ -62,8 +62,8 @@ const EquipmentSelection: React.FC<EquipmentSelectionProps> = ({
                 <option value="">Select equipment...</option>
                 {products.map(equipment => (
                   <option key={equipment.id} value={equipment.id} disabled={equipment.stock_quantity <= 0}>
-                    {equipment.name} - ${equipment.price_per_day}/day
-                    {equipment.availability_status === 'Out of Stock' ? ' (Out of Stock)' : 
+                    {equipment.name} - ${equipment.price_per_day}/day | ${Number(equipment.price_per_day * 5).toFixed(2)}/week
+                    {equipment.availability_status === 'Out of Stock' ? ' (Out of Stock)' :
                      equipment.availability_status === 'Low Stock' ? ` (Low Stock: ${equipment.stock_quantity} left)` : ''}
                     {/* Fallback for safety, though availability_status should be set */}
                     {!equipment.availability_status && equipment.stock_quantity <= 0 ? ' (Out of stock)' : 
@@ -110,8 +110,9 @@ const EquipmentSelection: React.FC<EquipmentSelectionProps> = ({
                     <div>
                       <p className="font-medium">{item.equipment_name}</p>
                       <p className="text-sm text-gray-600">
-                        Quantity: {item.quantity} × ${item.equipment_price}/day {/* Use equipment_price from BookingItem */}
-                      </p>
+                          Quantity: {item.quantity} × ${item.equipment_price}/day |
+                          ${Number(item.equipment_price * 5).toFixed(2)}/week {/* Use equipment_price from BookingItem */}
+                        </p>
                     </div>
                   </div>
                   <Button

--- a/src/components/equipment/EquipmentCard.tsx
+++ b/src/components/equipment/EquipmentCard.tsx
@@ -87,7 +87,8 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
         <div className="space-y-2">
           <div className="flex justify-between items-center">
             <span className="text-2xl font-bold text-primary">
-              ${equipment.price.toFixed(2)}/day
+              ${equipment.price.toFixed(2)}/day |
+              ${Number(equipment.price * 5).toFixed(2)}/week
             </span>
           </div>
           

--- a/src/components/homepage/FeaturedProducts.tsx
+++ b/src/components/homepage/FeaturedProducts.tsx
@@ -61,7 +61,8 @@ export const FeaturedProducts = () => {
                                     </p>
                                 )}
                                 <div className="text-lg font-bold mb-4">
-                                    ${Number(product.price_per_day).toFixed(2)}/day
+                                    ${Number(product.price_per_day).toFixed(2)}/day |
+                                    ${Number(product.price_per_day * 5).toFixed(2)}/week
                                 </div>
                                 <Link to="/equipment" className="block">
                                     <Button className="w-full">View All</Button>


### PR DESCRIPTION
## Summary
- show weekly prices alongside daily prices for homepage featured products
- include weekly prices in equipment cards
- update booking equipment selector and summary items to display weekly rates
- show weekly rates in admin product cards

## Testing
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_686502e1f480832ba6cad81a54e4e6c6