### PR TITLE
Add analytics dashboard with TLA branding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ VITE_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # Cloudflare Images Configuration
 CLOUDFLARE_ACCOUNT_ID=your-cloudflare-account-id
 CLOUDFLARE_API_TOKEN=your-cloudflare-api-token
+VITE_UMAMI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# Welcome to your Lovable project
+# Travel Light Aruba
 
 ## Project info
 
-**URL**: https://lovable.dev/projects/c9f55d9a-6a4d-42a9-a8e5-b94b970d9ea7
+**URL**: https://travellightaruba.com
 
 ## How can I edit this code?
 
 There are several ways of editing your application.
 
-**Use Lovable**
+**Use the Travel Light Aruba builder**
 
-Simply visit the [Lovable Project](https://lovable.dev/projects/c9f55d9a-6a4d-42a9-a8e5-b94b970d9ea7) and start prompting.
+Visit your [Travel Light Aruba project](https://travellightaruba.com) to make changes directly in the online editor.
 
-Changes made via Lovable will be committed automatically to this repo.
+Changes made via the builder will be committed automatically to this repo.
 
 **Use your preferred IDE**
 
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
+If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in the builder.
 
 The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
 
@@ -62,15 +62,15 @@ This project is built with:
 
 ## How can I deploy this project?
 
-Simply open [Lovable](https://lovable.dev/projects/c9f55d9a-6a4d-42a9-a8e5-b94b970d9ea7) and click on Share -> Publish.
+Simply open the Travel Light Aruba builder and click on Share -> Publish.
 
-## Can I connect a custom domain to my Lovable project?
+## Can I connect a custom domain to my site?
 
 Yes, you can!
 
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+Read more in our documentation about [setting up a custom domain](https://travellightaruba.com/docs/custom-domain)
 
 ## Environment variables
 

--- a/index.html
+++ b/index.html
@@ -15,11 +15,12 @@
     <meta property="og:title" content="TLA - Premium Beach & Baby Equipment Rentals in Aruba" />
     <meta property="og:description" content="Premium Beach & Baby Equipment Rentals in Aruba" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta property="og:image" content="https://abofxrgdxfzrhjbvhdkj.supabase.co/storage/v1/object/public/site-assets/favicon/1751031479742-TLA-Favicon.png" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@lovable_dev" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta name="twitter:site" content="@travellightaruba" />
+    <meta name="twitter:image" content="https://abofxrgdxfzrhjbvhdkj.supabase.co/storage/v1/object/public/site-assets/favicon/1751031479742-TLA-Favicon.png" />
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="79d3968a-436f-4946-9d49-a87feb3a65c4"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -28,6 +28,7 @@ export const AdminSidebar = ({ activeSection, onSectionChange }: AdminSidebarPro
     { id: 'equipment', label: 'Equipment', icon: Package, permission: 'ProductManagement' },
     { id: 'categories', label: 'Category Order', icon: ListOrdered, permission: 'CategoryManagement' },
     { id: 'reports', label: 'Reports', icon: FileText, permission: 'ReportingAccess' }, // Added Reports
+    { id: 'analytics', label: 'Analytics', icon: BarChart3, permission: 'ReportingAccess' },
     { id: 'users', label: 'User Management', icon: Users, permission: 'UserManagement' },
     { id: 'visibility', label: 'Visibility Settings', icon: Eye, permission: 'VisibilitySettings' },
     { id: 'tasks', label: 'My Tasks', icon: MapPin, permission: 'DriverTasks' },

--- a/src/components/admin/AnalyticsDashboard.tsx
+++ b/src/components/admin/AnalyticsDashboard.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import Spinner from '@/components/common/Spinner';
+
+const WEBSITE_ID = '79d3968a-436f-4946-9d49-a87feb3a65c4';
+const API_KEY = import.meta.env.VITE_UMAMI_API_KEY;
+
+interface UmamiStats {
+  pageviews: number;
+  uniques: number;
+}
+
+export const AnalyticsDashboard: React.FC = () => {
+  const [stats, setStats] = useState<UmamiStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const start = new Date();
+        start.setDate(start.getDate() - 7);
+        const res = await fetch(
+          `https://cloud.umami.is/api/websites/${WEBSITE_ID}/stats?start_at=${start.getTime()}`,
+          {
+            headers: { Authorization: `Bearer ${API_KEY}` },
+          }
+        );
+        if (!res.ok) throw new Error('Failed to fetch analytics');
+        const data = await res.json();
+        setStats({
+          pageviews: data.pageviews?.value ?? 0,
+          uniques: data.uniques?.value ?? 0,
+        });
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError('Failed to fetch analytics');
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchStats();
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Website Analytics</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading && <Spinner />}
+          {error && <p className="text-red-500">{error}</p>}
+          {stats && !loading && !error && (
+            <div className="flex gap-8">
+              <div>
+                <p className="text-sm text-gray-600">Pageviews</p>
+                <p className="text-2xl font-bold">{stats.pageviews}</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">Unique Visitors</p>
+                <p className="text-2xl font-bold">{stats.uniques}</p>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -12,6 +12,7 @@ import { CategoryManagement } from '@/components/admin/CategoryManagement';
 import { BookingAssignment } from '@/components/admin/BookingAssignment';
 import { DriverTasks } from '@/components/admin/DriverTasks';
 import { ReportsDashboard } from '@/components/admin/ReportsDashboard'; // Import ReportsDashboard
+import { AnalyticsDashboard } from '@/components/admin/AnalyticsDashboard';
 import { SiteSettings } from '@/components/admin/SiteSettings';
 import { SeoManager } from '@/components/admin/SeoManager';
 
@@ -34,6 +35,8 @@ const Admin = () => {
         return <CategoryManagement />;
       case 'reports': // Add case for reports
         return <ReportsDashboard />;
+      case 'analytics':
+        return <AnalyticsDashboard />;
       case 'users':
         return <UserManagement />;
       case 'visibility':


### PR DESCRIPTION
## Summary
- add Umami API key env variable
- wire up `AnalyticsDashboard` to use env variable
- switch README and meta tags to Travel Light Aruba branding

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*
- `npm test` *(fails: SubGroupOrderSettings tests fail)*


------
https://chatgpt.com/codex/tasks/task_e_6865198977bc832bb1dd98184bd79ce7