### PR TITLE
Seed ReportingAccess visibility

### DIFF
--- a/scripts/seed-users.ts
+++ b/scripts/seed-users.ts
@@ -82,6 +82,10 @@ const componentVisibilitySettings: ComponentVisibility[] = [
     roles: { SuperUser: true, Admin: true, Booker: false, Driver: false }
   },
   {
+    component_name: 'ReportingAccess',
+    roles: { SuperUser: true, Admin: true, Booker: false, Driver: false }
+  },
+  {
     component_name: 'TaskMaster',
     roles: { SuperUser: true, Admin: true, Booker: false, Driver: false }
   },


### PR DESCRIPTION
## Summary
- add ReportingAccess entry in `seed-users.ts`

## Testing
- `npm run lint` *(fails: Unexpected any, no-useless-escape)*

------
https://chatgpt.com/codex/tasks/task_e_68652ed638d0832bbdc31c28c224f66f