### PR TITLE
Add metrics and active cases to Umami proxy

### DIFF
--- a/supabase/functions/umami-proxy/index.ts
+++ b/supabase/functions/umami-proxy/index.ts
@@ -44,6 +44,14 @@ serve(async (req) => {
         url = `${apiEndpoint}/websites/${websiteId}/pageviews?startAt=${params.startAt}&endAt=${params.endAt}&unit=${params.unit}&timezone=${params.timezone}`;
         break;
 
+      case 'getWebsiteMetrics':
+        url = `${apiEndpoint}/websites/${websiteId}/metrics?type=${params.type}&startAt=${params.startAt}&endAt=${params.endAt}&limit=${params.limit}&timezone=${params.timezone}`;
+        break;
+
+      case 'getWebsiteActive':
+        url = `${apiEndpoint}/websites/${websiteId}/active`;
+        break;
+
       default:
         return new Response(JSON.stringify({ error: 'Invalid method' }), {
           status: 400,


### PR DESCRIPTION
## Summary
- extend `umami-proxy` to handle metrics and real-time visitor requests

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm test` *(fails: vitest errors)*
- `npx supabase functions deploy umami-proxy` *(fails: Access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_6866768287b4832b9b9ed7a001c9dd4d