### PR TITLE
chore: hide login button

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -133,13 +133,7 @@ export const Header = () => {
                 )}
                 <Button variant="ghost" onClick={handleSignOut}>Logout</Button>
               </>
-            ) : (
-              <>
-                <Link to="/login">
-                  <Button variant="outline">Login</Button>
-                </Link>
-              </>
-            )}
+            ) : null}
           </div>
 
           <div className="md:hidden">

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -131,32 +131,30 @@ const MobileNav = () => {
           </Collapsible>
           <NavLink to="/about">About</NavLink>
           <NavLink to="/contact">Contact</NavLink>
-          <div className="mt-4 pt-4 border-t">
-            {loading ? (
-              <p className="px-3 py-2 text-gray-700">Loading...</p>
-            ) : user && profile ? (
-              <div className="space-y-2">
-                {profile.role === 'Booker' && (
-                  // Hide Book Now option for now
-                  <Button asChild className="w-full hidden" hidden onClick={() => setIsOpen(false)}>
-                    <Link to="/book">Book Now</Link>
+          {(loading || (user && profile)) && (
+            <div className="mt-4 pt-4 border-t">
+              {loading ? (
+                <p className="px-3 py-2 text-gray-700">Loading...</p>
+              ) : (
+                <div className="space-y-2">
+                  {profile.role === 'Booker' && (
+                    // Hide Book Now option for now
+                    <Button asChild className="w-full hidden" hidden onClick={() => setIsOpen(false)}>
+                      <Link to="/book">Book Now</Link>
+                    </Button>
+                  )}
+                  {dashboardLink && (
+                    <Button asChild variant="outline" className="w-full" onClick={() => setIsOpen(false)}>
+                      <Link to={dashboardLink.path}>{dashboardLink.label}</Link>
+                    </Button>
+                  )}
+                  <Button variant="ghost" className="w-full justify-start" onClick={handleSignOut}>
+                    Logout
                   </Button>
-                )}
-                {dashboardLink && (
-                  <Button asChild variant="outline" className="w-full" onClick={() => setIsOpen(false)}>
-                    <Link to={dashboardLink.path}>{dashboardLink.label}</Link>
-                  </Button>
-                )}
-                <Button variant="ghost" className="w-full justify-start" onClick={handleSignOut}>
-                  Logout
-                </Button>
-              </div>
-            ) : (
-              <Button asChild variant="outline" className="w-full" onClick={() => setIsOpen(false)}>
-                <Link to="/login">Login</Link>
-              </Button>
-            )}
-          </div>
+                </div>
+              )}
+            </div>
+          )}
         </nav>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
## Summary
- remove login button from desktop header and mobile navigation
- keep /login route available for direct access

## Testing
- `npm run lint` (fails: many existing lint errors)
- `npm test` (fails: TypeError reading 'alloc')

------
https://chatgpt.com/codex/tasks/task_e_68a2d4d6f8b4832b8e192b518686fcc5