### PR TITLE
feat: add equipment detail view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { AppPrefetch } from "@/AppPrefetch"; //
 // Lazy load all pages
 const Index = lazy(() => import("./pages/Index"));
 const Equipment = lazy(() => import("./pages/Equipment"));
+const EquipmentItem = lazy(() => import("./pages/EquipmentItem"));
 const About = lazy(() => import("./pages/About"));
 const Book = lazy(() => import("./pages/Book"));
 const Contact = lazy(() => import("./pages/Contact"));
@@ -60,6 +61,7 @@ const App = () => {
                     <Route path="/about-us" element={<About />} />
                     <Route path="/about" element={<About />} />
                     <Route path="/equipment" element={<Equipment />} />
+                    <Route path="/equipment/:slug" element={<EquipmentItem />} />
                     <Route path="/login" element={<Login />} />
 
                     {/* Protected Routes */}

--- a/src/components/equipment/EquipmentCard.d.ts
+++ b/src/components/equipment/EquipmentCard.d.ts
@@ -1,6 +1,7 @@
 interface Equipment {
     id: string;
     name: string;
+    slug: string;
     category: string;
     price: number;
     image: string;

--- a/src/components/equipment/EquipmentCard.test.tsx
+++ b/src/components/equipment/EquipmentCard.test.tsx
@@ -6,6 +6,7 @@ import { EquipmentCard } from './EquipmentCard';
 const equipment = {
   id: '1',
   name: 'Tent',
+  slug: 'tent',
   category: 'Camping',
   price: 10,
   image: '/tent.jpg',

--- a/src/components/equipment/EquipmentCard.tsx
+++ b/src/components/equipment/EquipmentCard.tsx
@@ -9,6 +9,7 @@ import DOMPurify from 'dompurify';
 interface Equipment {
   id: string;
   name: string;
+  slug: string;
   category: string;
   price: number;
   image: string;
@@ -58,28 +59,34 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
   return (
     <>
       <Card className="overflow-hidden hover:shadow-lg transition-shadow h-full flex flex-col justify-between">
-        <div className="aspect-square relative overflow-hidden">
-          <img
-            src={equipment.image}
-            alt={equipment.name}
-            className="w-full h-full object-cover hover:scale-105 transition-transform duration-300"
-          />
-          <div className="absolute top-2 right-2">
-            {equipment.availability !== 'unavailable' && (
-              <div
-                className={clsx(
-                  'text-xs font-medium px-2 py-1 rounded-full',
-                  getAvailabilityColor(equipment.availability)
-                )}
-              >
-                {getAvailabilityText(equipment.availability)}
-              </div>
-            )}
+        <Link to={`/equipment/${equipment.slug}`}>
+          <div className="aspect-square relative overflow-hidden">
+            <img
+              src={equipment.image}
+              alt={equipment.name}
+              className="w-full h-full object-cover hover:scale-105 transition-transform duration-300"
+            />
+            <div className="absolute top-2 right-2">
+              {equipment.availability !== 'unavailable' && (
+                <div
+                  className={clsx(
+                    'text-xs font-medium px-2 py-1 rounded-full',
+                    getAvailabilityColor(equipment.availability)
+                  )}
+                >
+                  {getAvailabilityText(equipment.availability)}
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        </Link>
 
         <CardHeader>
-          <CardTitle className="text-lg">{equipment.name}</CardTitle>
+          <CardTitle className="text-lg">
+            <Link to={`/equipment/${equipment.slug}`} className="hover:underline">
+              {equipment.name}
+            </Link>
+          </CardTitle>
           <div className="text-gray-600 text-sm line-clamp-2">
             <div dangerouslySetInnerHTML={{ __html: sanitizedDescription }} />
           </div>

--- a/src/pages/Equipment.tsx
+++ b/src/pages/Equipment.tsx
@@ -5,6 +5,7 @@ import { EquipmentCard } from '@/components/equipment/EquipmentCard';
 import { EquipmentFilters } from '@/components/equipment/EquipmentFilters';
 import { FaqAccordion } from '@/components/common/FaqAccordion';
 import { getProducts } from '@/lib/queries/products';
+import { slugify } from '@/utils/slugify';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
 import type { ActiveFiltersState } from '@/components/equipment/EquipmentFilters';
@@ -50,6 +51,7 @@ const Equipment = () => {
       return {
         id: p.id,
         name: p.name,
+        slug: slugify(p.name),
         category: p.equipment_category?.name || 'Uncategorized',
         sub_category: p.equipment_sub_category?.name || 'General',
         price: p.price_per_day,

--- a/src/pages/EquipmentItem.d.ts
+++ b/src/pages/EquipmentItem.d.ts
@@ -1,0 +1,2 @@
+declare const EquipmentItem: () => import("react/jsx-runtime").JSX.Element;
+export default EquipmentItem;

--- a/src/pages/EquipmentItem.tsx
+++ b/src/pages/EquipmentItem.tsx
@@ -1,0 +1,100 @@
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import DOMPurify from 'dompurify';
+import { Header } from '@/components/layout/Header';
+import { Footer } from '@/components/layout/Footer';
+import { getProducts } from '@/lib/queries/products';
+import { slugify } from '@/utils/slugify';
+
+const EquipmentItem = () => {
+  const { slug } = useParams<{ slug: string }>();
+
+  const { data: products = [], isLoading } = useQuery({
+    queryKey: ['equipment-products'],
+    queryFn: getProducts,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+
+  const equipment = useMemo(() => {
+    return products
+      .map((p) => {
+        const stock = p.stock_quantity ?? 0;
+        let availability: 'available' | 'limited' | 'unavailable';
+        if (stock <= 0) availability = 'unavailable';
+        else if (stock <= 5) availability = 'limited';
+        else availability = 'available';
+
+        return {
+          id: p.id,
+          name: p.name,
+          slug: slugify(p.name),
+          category: p.equipment_category?.name || 'Uncategorized',
+          price: p.price_per_day,
+          image: p.image_url || (p.images && p.images[0]) || '',
+          description: p.description || '',
+          availability,
+          features: [],
+        };
+      })
+      .find((item) => item.slug === slug);
+  }, [products, slug]);
+
+  const sanitizedDescription = useMemo(
+    () => DOMPurify.sanitize(equipment?.description || ''),
+    [equipment?.description]
+  );
+
+  if (isLoading) {
+    return <div className="py-8 text-center">Loading equipment...</div>;
+  }
+
+  if (!equipment) {
+    return (
+      <div className="flex flex-col min-h-screen">
+        <Header />
+        <main className="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <p className="text-center">Equipment not found.</p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main className="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="max-w-3xl mx-auto">
+          <h1 className="text-3xl font-bold mb-4">{equipment.name}</h1>
+          <img
+            src={equipment.image}
+            alt={equipment.name}
+            className="w-full h-64 object-cover rounded mb-4"
+          />
+          <div className="text-sm text-gray-700 whitespace-pre-line mb-4">
+            <div dangerouslySetInnerHTML={{ __html: sanitizedDescription }} />
+          </div>
+          <div className="text-sm mb-4">
+            <span className="font-semibold">Price:</span>{' '}
+            ${equipment.price.toFixed(2)}/day | ${Number(equipment.price * 5).toFixed(2)}/week
+          </div>
+          {equipment.features.length > 0 && (
+            <div className="text-sm">
+              <p className="font-medium">Features:</p>
+              <ul className="list-disc list-inside pl-1">
+                {equipment.features.map((feature, index) => (
+                  <li key={index}>{feature}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default EquipmentItem;

--- a/src/utils/slugify.d.ts
+++ b/src/utils/slugify.d.ts
@@ -1,0 +1,1 @@
+export declare const slugify: (str: string) => string;

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,0 +1,5 @@
+export const slugify = (str: string): string =>
+  str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '');


### PR DESCRIPTION
## Summary
- generate slugs for equipment items
- add equipment detail page
- link equipment cards to detail pages

## Testing
- `npm test -- --run` *(fails: Cannot read properties of undefined (reading 'alloc'))*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d91dfe78832ba8034a8065f036e7