### PR TITLE
feat: add share buttons for equipment pages

### DIFF
--- a/src/components/equipment/EquipmentCard.tsx
+++ b/src/components/equipment/EquipmentCard.tsx
@@ -5,6 +5,8 @@ import { Link } from 'react-router-dom';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import clsx from 'clsx';
 import DOMPurify from 'dompurify';
+import { Share2 } from 'lucide-react';
+import { toast } from '@/components/ui/use-toast';
 
 interface Equipment {
   id: string;
@@ -56,6 +58,24 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
     }
   };
 
+  const handleShare = async () => {
+    const url = `${window.location.origin}/equipment/${equipment.slug}`;
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: equipment.name, url });
+        return;
+      } catch {
+        // fall back to clipboard on share failure
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(url);
+      toast({ title: 'Link copied' });
+    } catch (err) {
+      console.error('Share failed', err);
+    }
+  };
+
   return (
     <>
       <Card className="overflow-hidden hover:shadow-lg transition-shadow h-full flex flex-col justify-between">
@@ -82,11 +102,21 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
         </Link>
 
         <CardHeader>
-          <CardTitle className="text-lg">
-            <Link to={`/equipment/${equipment.slug}`} className="hover:underline">
-              {equipment.name}
-            </Link>
-          </CardTitle>
+          <div className="flex items-start justify-between">
+            <CardTitle className="text-lg">
+              <Link to={`/equipment/${equipment.slug}`} className="hover:underline">
+                {equipment.name}
+              </Link>
+            </CardTitle>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handleShare}
+              aria-label="Share"
+            >
+              <Share2 className="h-4 w-4" />
+            </Button>
+          </div>
           <div className="text-gray-600 text-sm line-clamp-2">
             <div dangerouslySetInnerHTML={{ __html: sanitizedDescription }} />
           </div>

--- a/src/pages/EquipmentItem.tsx
+++ b/src/pages/EquipmentItem.tsx
@@ -6,6 +6,9 @@ import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
 import { getProducts } from '@/lib/queries/products';
 import { slugify } from '@/utils/slugify';
+import { Button } from '@/components/ui/button';
+import { Share2 } from 'lucide-react';
+import { toast } from '@/components/ui/use-toast';
 
 const EquipmentItem = () => {
   const { slug } = useParams<{ slug: string }>();
@@ -46,6 +49,25 @@ const EquipmentItem = () => {
     [equipment?.description]
   );
 
+  const handleShare = async () => {
+    if (!equipment) return;
+    const url = `${window.location.origin}/equipment/${equipment.slug}`;
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: equipment.name, url });
+        return;
+      } catch {
+        // fallback to clipboard on share failure
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(url);
+      toast({ title: 'Link copied' });
+    } catch (err) {
+      console.error('Share failed', err);
+    }
+  };
+
   if (isLoading) {
     return <div className="py-8 text-center">Loading equipment...</div>;
   }
@@ -67,7 +89,17 @@ const EquipmentItem = () => {
       <Header />
       <main className="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="max-w-3xl mx-auto">
-          <h1 className="text-3xl font-bold mb-4">{equipment.name}</h1>
+          <div className="flex items-center justify-between mb-4">
+            <h1 className="text-3xl font-bold">{equipment.name}</h1>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handleShare}
+              aria-label="Share"
+            >
+              <Share2 className="h-5 w-5" />
+            </Button>
+          </div>
           <img
             src={equipment.image}
             alt={equipment.name}


### PR DESCRIPTION
## Summary
- add share action to equipment cards with clipboard fallback and toast feedback
- enable sharing from equipment item pages using native share API when available

## Testing
- `npm test` (fails: TypeError: Cannot read properties of undefined (reading 'alloc'))
- `npm run lint` (fails: 187 problems (164 errors, 23 warnings))

------
https://chatgpt.com/codex/tasks/task_e_68a2db2c4c28832b8311d3a1a66723a5