### PR TITLE
Format revenue values to two decimals

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -123,7 +123,7 @@ export const AdminDashboard = () => {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-gray-600">Total Revenue</p>
-                <p className="text-2xl font-bold text-gray-900">${stats.totalRevenue}</p>
+                <p className="text-2xl font-bold text-gray-900">${stats.totalRevenue.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</p>
               </div>
               <div className="h-12 w-12 bg-green-100 rounded-lg flex items-center justify-center">
                 <DollarSign className="h-6 w-6 text-green-600" />

--- a/src/components/admin/EnhancedReportsDashboard.tsx
+++ b/src/components/admin/EnhancedReportsDashboard.tsx
@@ -484,7 +484,7 @@ export const EnhancedReportsDashboard: React.FC = () => {
                 <TrendingUp className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">${data?.business.totalRevenue.toLocaleString() || 0}</div>
+                <div className="text-2xl font-bold">${(data?.business.totalRevenue ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</div>
                 <p className="text-xs text-muted-foreground">Last 30 days</p>
               </CardContent>
             </Card>
@@ -574,7 +574,9 @@ export const EnhancedReportsDashboard: React.FC = () => {
           <Card>
             <CardHeader>
               <CardTitle>Revenue Overview</CardTitle>
-              <CardDescription>Total revenue: ${data?.business.totalRevenue.toLocaleString()}</CardDescription>
+              <CardDescription>Total revenue: ${(
+                data?.business.totalRevenue ?? 0
+              ).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</CardDescription>
             </CardHeader>
             <CardContent>
               {data?.business.revenueTrends.length ? (
@@ -583,7 +585,12 @@ export const EnhancedReportsDashboard: React.FC = () => {
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="month" />
                     <YAxis />
-                    <Tooltip formatter={(value: any) => [`$${value?.toLocaleString() || 0}`, 'Revenue']} />
+                    <Tooltip
+                      formatter={(value: number) => [
+                        `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+                        'Revenue',
+                      ]}
+                    />
                     <Bar dataKey="revenue" fill="#82ca9d" name="Monthly Revenue" />
                   </BarChart>
                 </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- Format total revenue on Admin dashboard to always show two decimals
- Ensure revenue values in enhanced reports dashboard use localized two-decimal formatting
- Update revenue tooltip to match two-decimal currency style

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'alloc'))*
- `npm run lint` *(fails: 186 problems (163 errors, 23 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a2f1813d9c832bafcb062a9661218c