### PR TITLE
feat: add image carousels for equipment

### DIFF
--- a/src/components/equipment/EquipmentCard.d.ts
+++ b/src/components/equipment/EquipmentCard.d.ts
@@ -5,6 +5,7 @@ interface Equipment {
     category: string;
     price: number;
     image: string;
+    images: string[];
     description: string;
     availability: 'available' | 'limited' | 'unavailable';
     features: string[];

--- a/src/components/equipment/EquipmentCard.test.tsx
+++ b/src/components/equipment/EquipmentCard.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import { describe, it, expect } from 'vitest';
 import { EquipmentCard } from './EquipmentCard';
@@ -9,13 +10,14 @@ const equipment = {
   slug: 'tent',
   category: 'Camping',
   price: 10,
-  image: '/tent.jpg',
+  image: '/thumb.jpg',
+  images: ['/tent1.jpg', '/tent2.jpg'],
   description: '<b>Single</b><br><script>alert("xss")</script>',
   availability: 'available' as const,
   features: [] as string[],
 };
 
-describe('EquipmentCard sanitation', () => {
+describe('EquipmentCard', () => {
   it('renders sanitized HTML description', () => {
     render(
       <BrowserRouter>
@@ -25,5 +27,19 @@ describe('EquipmentCard sanitation', () => {
     const bold = screen.getByText('Single');
     expect(bold.tagName).toBe('B');
     expect(document.querySelector('script')).toBeNull();
+  });
+
+  it('renders images in modal carousel', async () => {
+    const user = userEvent.setup();
+    render(
+      <BrowserRouter>
+        <EquipmentCard equipment={equipment} />
+      </BrowserRouter>
+    );
+    await user.click(screen.getByText('Read more'));
+    const dialog = await screen.findByRole('dialog');
+    const imgs = within(dialog).getAllByRole('img');
+    expect(imgs).toHaveLength(equipment.images.length);
+    expect(imgs[0]).toHaveAttribute('src', equipment.images[0]);
   });
 });

--- a/src/components/equipment/EquipmentCard.tsx
+++ b/src/components/equipment/EquipmentCard.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/componen
 import { Button } from '@/components/ui/button';
 import { Link } from 'react-router-dom';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext } from '@/components/ui/carousel';
 import clsx from 'clsx';
 import DOMPurify from 'dompurify';
 import { Share2 } from 'lucide-react';
@@ -15,6 +16,7 @@ interface Equipment {
   category: string;
   price: number;
   image: string;
+  images: string[];
   description: string;
   availability: 'available' | 'limited' | 'unavailable';
   features: string[];
@@ -172,11 +174,29 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
             <DialogTitle>{equipment.name}</DialogTitle>
           </DialogHeader>
 
-          <img
-            src={equipment.image}
-            alt={equipment.name}
-            className="w-full h-64 object-cover rounded mb-4"
-          />
+          {equipment.images.length > 0 ? (
+            <Carousel className="w-full mb-4">
+              <CarouselContent>
+                {equipment.images.map((img, idx) => (
+                  <CarouselItem key={idx}>
+                    <img
+                      src={img}
+                      alt={`${equipment.name} image ${idx + 1}`}
+                      className="w-full h-64 object-cover rounded"
+                    />
+                  </CarouselItem>
+                ))}
+              </CarouselContent>
+              <CarouselPrevious />
+              <CarouselNext />
+            </Carousel>
+          ) : (
+            <img
+              src={equipment.image}
+              alt={equipment.name}
+              className="w-full h-64 object-cover rounded mb-4"
+            />
+          )}
 
           <div className="text-sm text-gray-700 whitespace-pre-line mb-2">
             <div dangerouslySetInnerHTML={{ __html: sanitizedDescription }} />

--- a/src/pages/Equipment.tsx
+++ b/src/pages/Equipment.tsx
@@ -56,6 +56,7 @@ const Equipment = () => {
         sub_category: p.equipment_sub_category?.name || 'General',
         price: p.price_per_day,
         image: p.image_url || (p.images && p.images[0]) || '',
+        images: p.images || (p.image_url ? [p.image_url] : []),
         description: p.description || '',
         availability,
         features: [],

--- a/src/pages/EquipmentItem.tsx
+++ b/src/pages/EquipmentItem.tsx
@@ -9,6 +9,7 @@ import { slugify } from '@/utils/slugify';
 import { Button } from '@/components/ui/button';
 import { Share2 } from 'lucide-react';
 import { toast } from '@/components/ui/use-toast';
+import { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext } from '@/components/ui/carousel';
 
 const EquipmentItem = () => {
   const { slug } = useParams<{ slug: string }>();
@@ -36,6 +37,7 @@ const EquipmentItem = () => {
           category: p.equipment_category?.name || 'Uncategorized',
           price: p.price_per_day,
           image: p.image_url || (p.images && p.images[0]) || '',
+          images: p.images || (p.image_url ? [p.image_url] : []),
           description: p.description || '',
           availability,
           features: [],
@@ -100,11 +102,29 @@ const EquipmentItem = () => {
               <Share2 className="h-5 w-5" />
             </Button>
           </div>
-          <img
-            src={equipment.image}
-            alt={equipment.name}
-            className="w-full h-64 object-cover rounded mb-4"
-          />
+          {equipment.images.length > 0 ? (
+            <Carousel className="w-full mb-4">
+              <CarouselContent>
+                {equipment.images.map((img, idx) => (
+                  <CarouselItem key={idx}>
+                    <img
+                      src={img}
+                      alt={`${equipment.name} image ${idx + 1}`}
+                      className="w-full h-64 object-cover rounded"
+                    />
+                  </CarouselItem>
+                ))}
+              </CarouselContent>
+              <CarouselPrevious />
+              <CarouselNext />
+            </Carousel>
+          ) : (
+            <img
+              src={equipment.image}
+              alt={equipment.name}
+              className="w-full h-64 object-cover rounded mb-4"
+            />
+          )}
           <div className="text-sm text-gray-700 whitespace-pre-line mb-4">
             <div dangerouslySetInnerHTML={{ __html: sanitizedDescription }} />
           </div>


### PR DESCRIPTION
## Summary
- expand product mapping to include full image arrays
- display image carousels in equipment modals and item pages
- test carousel rendering with multiple images

## Testing
- `npm test -- --run` (fails: Cannot read properties of undefined (reading 'alloc'))
- `npm run lint` (fails: 186 problems)

------
https://chatgpt.com/codex/tasks/task_e_68a2fe8b81fc832bba172c836ccd51aa