### PR TITLE
feat: preserve image aspect ratios

### DIFF
--- a/src/components/admin/CloudflareImageBrowser.tsx
+++ b/src/components/admin/CloudflareImageBrowser.tsx
@@ -168,11 +168,11 @@ export const CloudflareImageBrowser: React.FC<CloudflareImageBrowserProps> = ({
                       )}
                       onClick={() => handleImageClick(image)}
                     >
-                      <img
-                        src={imageUrl}
-                        alt={image.filename}
-                        className="w-full h-full object-cover rounded-lg"
-                        onError={(e) => {
+                        <img
+                          src={imageUrl}
+                          alt={image.filename}
+                          className="w-full h-full object-contain rounded-lg"
+                          onError={(e) => {
                           const target = e.target as HTMLImageElement;
                           target.style.display = 'none';
                           target.nextElementSibling?.classList.remove('hidden');

--- a/src/components/admin/CloudflareImageUpload.tsx
+++ b/src/components/admin/CloudflareImageUpload.tsx
@@ -151,11 +151,11 @@ export const CloudflareImageUpload: React.FC<CloudflareImageUploadProps> = ({
           {selectedImageUrl && !previewUrl && (
             <div className="space-y-2">
               <p className="text-sm font-medium">Current image:</p>
-              <img 
-                src={selectedImageUrl} 
-                alt="Current" 
-                className="w-20 h-20 object-cover rounded border"
-              />
+                <img
+                  src={selectedImageUrl}
+                  alt="Current"
+                  className="w-20 h-auto max-h-20 object-contain rounded border"
+                />
             </div>
           )}
 
@@ -173,11 +173,11 @@ export const CloudflareImageUpload: React.FC<CloudflareImageUploadProps> = ({
           >
             {previewUrl ? (
               <div className="space-y-2">
-                <img 
-                  src={previewUrl} 
-                  alt="Preview" 
-                  className="w-32 h-32 object-cover rounded mx-auto"
-                />
+                  <img
+                    src={previewUrl}
+                    alt="Preview"
+                    className="w-32 h-auto max-h-32 object-contain rounded mx-auto"
+                  />
                 <p className="text-sm text-gray-600">Preview</p>
               </div>
             ) : (

--- a/src/components/admin/HighlightProductsSettings.tsx
+++ b/src/components/admin/HighlightProductsSettings.tsx
@@ -138,13 +138,13 @@ export const HighlightProductsSettings = () => {
               {orderedProducts.map((product, index) => (
                 <div key={product.id} className="flex items-center justify-between bg-blue-50 p-2 rounded">
                   <div className="flex items-center gap-2">
-                    {product.images?.[0] && (
-                      <img
-                        src={product.images[0]}
-                        alt={product.name}
-                        className="w-10 h-10 object-cover rounded"
-                      />
-                    )}
+                      {product.images?.[0] && (
+                        <img
+                          src={product.images[0]}
+                          alt={product.name}
+                          className="w-10 h-auto max-h-10 object-contain rounded"
+                        />
+                      )}
                     <span className="font-medium">{product.name}</span>
                   </div>
                   <div className="flex items-center gap-1">
@@ -192,13 +192,13 @@ export const HighlightProductsSettings = () => {
                   checked={selected.includes(product.id)}
                   onCheckedChange={() => toggle(product.id)}
                 />
-                {product.images?.[0] && (
-                  <img
-                    src={product.images[0]}
-                    alt={product.name}
-                    className="w-12 h-12 object-cover rounded"
-                  />
-                )}
+                  {product.images?.[0] && (
+                    <img
+                      src={product.images[0]}
+                      alt={product.name}
+                      className="w-12 h-auto max-h-12 object-contain rounded"
+                    />
+                  )}
                 <span className="font-medium">{product.name}</span>
               </label>
             ))}

--- a/src/components/admin/ProductCard.tsx
+++ b/src/components/admin/ProductCard.tsx
@@ -25,9 +25,13 @@ export const ProductCard = ({ product, onEdit, onDelete, onToggleAvailability }:
 
   return (
     <Card key={product.id} className="flex flex-col">
-      {product.images?.[0] && (
-        <img src={product.images[0]} alt={product.name} className="w-full h-48 object-cover rounded-t-lg" />
-      )}
+        {product.images?.[0] && (
+          <img
+            src={product.images[0]}
+            alt={product.name}
+            className="w-full h-auto max-h-48 object-contain rounded-t-lg"
+          />
+        )}
       <CardHeader className="flex-grow-0">
         <div className="flex items-center justify-between">
           <CardTitle className="text-lg">{product.name}</CardTitle>

--- a/src/components/admin/ProductManagement.tsx
+++ b/src/components/admin/ProductManagement.tsx
@@ -212,11 +212,11 @@ export const ProductManagement = () => {
               <div className="flex flex-wrap gap-2">
                 {formState.images.map((url: string, idx: number) => (
                   <div key={idx} className="relative">
-                    <img
-                      src={url}
-                      alt={`Selected ${idx + 1}`}
-                      className="w-20 h-20 object-cover rounded border"
-                    />
+                      <img
+                        src={url}
+                        alt={`Selected ${idx + 1}`}
+                        className="w-20 h-auto max-h-20 object-contain rounded border"
+                      />
                     <Button
                       type="button"
                       variant="destructive"

--- a/src/components/booking/EquipmentSelection.tsx
+++ b/src/components/booking/EquipmentSelection.tsx
@@ -101,12 +101,12 @@ const EquipmentSelection: React.FC<EquipmentSelectionProps> = ({
               return item.equipment_name && equipmentDetails ? ( // Ensure equipmentDetails is found
                 <div key={item.equipment_id} className="flex items-center justify-between p-3 bg-gray-50 rounded">
                   <div className="flex items-center gap-3">
-                    <img
-                      src={equipmentDetails.images?.[0] || undefined}
-                      alt={item.equipment_name}
-                      className="w-12 h-12 object-cover rounded"
-                      onError={(e) => (e.currentTarget.style.display = 'none')}
-                    />
+                      <img
+                        src={equipmentDetails.images?.[0] || undefined}
+                        alt={item.equipment_name}
+                        className="w-12 h-auto max-h-12 object-contain rounded"
+                        onError={(e) => (e.currentTarget.style.display = 'none')}
+                      />
                     <div>
                       <p className="font-medium">{item.equipment_name}</p>
                       <p className="text-sm text-gray-600">

--- a/src/components/equipment/EquipmentCard.tsx
+++ b/src/components/equipment/EquipmentCard.tsx
@@ -8,7 +8,6 @@ import clsx from 'clsx';
 import DOMPurify from 'dompurify';
 import { Share2 } from 'lucide-react';
 import { toast } from '@/components/ui/use-toast';
-import { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext } from '@/components/ui/carousel';
 
 interface Equipment {
   id: string;
@@ -81,18 +80,18 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
   };
 
   return (
-    <>
-      <Card className="overflow-hidden hover:shadow-lg transition-shadow h-full flex flex-col justify-between">
-        <Link to={`/equipment/${equipment.slug}`}>
-          <div className="aspect-square relative overflow-hidden">
-            {equipment.images[0] && (
-              <img
-                src={equipment.images[0]}
-                alt={equipment.name}
-                className="w-full h-full object-cover hover:scale-105 transition-transform duration-300"
-              />
-            )}
-            <div className="absolute top-2 right-2">
+      <>
+        <Card className="overflow-hidden hover:shadow-lg transition-shadow h-full flex flex-col justify-between">
+          <Link to={`/equipment/${equipment.slug}`}>
+            <div className="relative overflow-hidden flex items-center justify-center">
+              {equipment.images[0] && (
+                <img
+                  src={equipment.images[0]}
+                  alt={equipment.name}
+                  className="w-full h-auto object-contain hover:scale-105 transition-transform duration-300"
+                />
+              )}
+              <div className="absolute top-2 right-2">
               {equipment.availability !== 'unavailable' && (
                 <div
                   className={clsx(
@@ -172,39 +171,35 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
       </Card>
 
       {/* 🔵 MODAL */}
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-lg sm:max-w-xl">
-          <DialogHeader>
-            <DialogTitle>{equipment.name}</DialogTitle>
-          </DialogHeader>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogContent className="max-w-lg sm:max-w-xl">
+            <DialogHeader>
+              <DialogTitle>{equipment.name}</DialogTitle>
+            </DialogHeader>
 
-          {equipment.images.length > 0 && (
-
-          {equipment.images.length > 0 ? (
-
-            <Carousel className="w-full mb-4">
-              <CarouselContent>
-                {equipment.images.map((img, idx) => (
-                  <CarouselItem key={idx}>
-                    <img
-                      src={img}
-                      alt={`${equipment.name} image ${idx + 1}`}
-                      className="w-full h-64 object-cover rounded"
-                    />
-                  </CarouselItem>
-                ))}
-              </CarouselContent>
-              <CarouselPrevious />
-              <CarouselNext />
-            </Carousel>
-          ) : (
-            <img
-              src={equipment.image}
-              alt={equipment.name}
-              className="w-full h-64 object-cover rounded mb-4"
-            />
-
-          )}
+            {equipment.images.length > 0 ? (
+              <Carousel className="w-full mb-4">
+                <CarouselContent>
+                  {equipment.images.map((img, idx) => (
+                    <CarouselItem key={idx}>
+                      <img
+                        src={img}
+                        alt={`${equipment.name} image ${idx + 1}`}
+                        className="w-full h-auto max-h-96 object-contain rounded"
+                      />
+                    </CarouselItem>
+                  ))}
+                </CarouselContent>
+                <CarouselPrevious />
+                <CarouselNext />
+              </Carousel>
+            ) : (
+              <img
+                src={equipment.image}
+                alt={equipment.name}
+                className="w-full h-auto max-h-96 object-contain rounded mb-4"
+              />
+            )}
 
           <div className="text-sm text-gray-700 whitespace-pre-line mb-2">
             <div dangerouslySetInnerHTML={{ __html: sanitizedDescription }} />

--- a/src/components/homepage/FeaturedProducts.tsx
+++ b/src/components/homepage/FeaturedProducts.tsx
@@ -44,13 +44,13 @@ export const FeaturedProducts = () => {
                             key={product.id}
                             className="overflow-hidden hover:shadow-lg transition-shadow"
                         >
-                            {product.images?.[0] && (
-                                <img
-                                    src={product.images[0]}
-                                    alt={product.name}
-                                    className="w-full h-48 object-cover"
-                                />
-                            )}
+                              {product.images?.[0] && (
+                                  <img
+                                      src={product.images[0]}
+                                      alt={product.name}
+                                      className="w-full h-auto max-h-48 object-contain"
+                                  />
+                              )}
                             <CardHeader>
                                 <CardTitle className="text-xl">{product.name}</CardTitle>
                             </CardHeader>

--- a/src/pages/EquipmentItem.tsx
+++ b/src/pages/EquipmentItem.tsx
@@ -107,10 +107,7 @@ const EquipmentItem = () => {
             </Button>
           </div>
 
-          {equipment.images.length > 0 && (
-
           {equipment.images.length > 0 ? (
-
             <Carousel className="w-full mb-4">
               <CarouselContent>
                 {equipment.images.map((img, idx) => (
@@ -118,7 +115,7 @@ const EquipmentItem = () => {
                     <img
                       src={img}
                       alt={`${equipment.name} image ${idx + 1}`}
-                      className="w-full h-64 object-cover rounded"
+                      className="w-full h-auto max-h-96 object-contain rounded"
                     />
                   </CarouselItem>
                 ))}
@@ -126,14 +123,12 @@ const EquipmentItem = () => {
               <CarouselPrevious />
               <CarouselNext />
             </Carousel>
-
           ) : (
             <img
               src={equipment.image}
               alt={equipment.name}
-              className="w-full h-64 object-cover rounded mb-4"
+              className="w-full h-auto max-h-96 object-contain rounded mb-4"
             />
-
           )}
           <div className="text-sm text-gray-700 whitespace-pre-line mb-4">
             <div dangerouslySetInnerHTML={{ __html: sanitizedDescription }} />


### PR DESCRIPTION
## Summary
- show equipment page images using `object-contain` and flexible height
- allow EquipmentCard and modal carousels to display natural aspect ratios
- update product and admin image components to follow same sizing pattern

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'alloc'))*
- `npm run lint` *(fails: 189 problems, Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a309cfae44832b93b4eaaa6aeeb70a