### PR TITLE
Add user association to bookings

### DIFF
--- a/src/components/admin/calendar/types.ts
+++ b/src/components/admin/calendar/types.ts
@@ -18,6 +18,7 @@ export interface Booking {
   customer_email: string;
   customer_phone: string;
   customer_address: string;
+  user_id: string;
   start_date: string;
   end_date: string;
   status: BookingStatus;

--- a/src/hooks/useBooking.ts
+++ b/src/hooks/useBooking.ts
@@ -4,6 +4,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { Product, BookingFormData, BookingItem, CustomerInfo, AvailabilityStatus, SupabaseBookingData } from '../types/types';
 import { SupabaseBookingItemData } from '../types/booking'; // Import from the new file
 import { useToast } from '@/components/ui/use-toast';
+import { useAuth } from '@/hooks/useAuth';
 
 // All interfaces like Product, BookingFormData, BookingItem, CustomerInfo, 
 // SupabaseBookingData, SupabaseBookingItemData are now imported from '../types/types'.
@@ -28,6 +29,7 @@ const useBooking = () => {
   const [quantity, setQuantity] = useState(1);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
+  const { user } = useAuth();
 
   useEffect(() => {
     const fetchProducts = async () => {
@@ -229,6 +231,11 @@ const useBooking = () => {
       setIsSubmitting(false);
       return;
     }
+    if (!user) {
+      toast({ title: 'Authentication Error', description: 'You must be logged in to create a booking.', variant: 'destructive' });
+      setIsSubmitting(false);
+      return;
+    }
 
     try {
       const days = calculateDays();
@@ -238,7 +245,8 @@ const useBooking = () => {
         return;
       }
 
-      const bookingPayload: Omit<SupabaseBookingData, 'user_id' | 'created_at' | 'total_price' | 'customer_address'> & { customer_address: string } = {
+      const bookingPayload: Omit<SupabaseBookingData, 'created_at' | 'total_price' | 'customer_address'> & { customer_address: string } = {
+        user_id: user.id,
         start_date: bookingData.startDate,
         end_date: bookingData.endDate,
         customer_name: bookingData.customerInfo.name,

--- a/src/integrations/supabase/client.d.ts
+++ b/src/integrations/supabase/client.d.ts
@@ -52,6 +52,7 @@ export declare const supabase: import("@supabase/supabase-js").SupabaseClient<Da
                 delivery_failure_reason: string | null;
                 end_date: string;
                 id: string;
+                user_id: string | null;
                 start_date: string;
                 status: string;
                 total_amount: number;
@@ -67,6 +68,7 @@ export declare const supabase: import("@supabase/supabase-js").SupabaseClient<Da
                 delivery_failure_reason?: string | null;
                 end_date: string;
                 id?: string;
+                user_id?: string | null;
                 start_date: string;
                 status?: string;
                 total_amount: number;
@@ -82,12 +84,21 @@ export declare const supabase: import("@supabase/supabase-js").SupabaseClient<Da
                 delivery_failure_reason?: string | null;
                 end_date?: string;
                 id?: string;
+                user_id?: string | null;
                 start_date?: string;
                 status?: string;
                 total_amount?: number;
                 updated_at?: string;
             };
-            Relationships: [];
+            Relationships: [
+                {
+                    foreignKeyName: "bookings_user_id_fkey";
+                    columns: ["user_id"];
+                    isOneToOne: false;
+                    referencedRelation: "profiles";
+                    referencedColumns: ["id"];
+                }
+            ];
         };
         component_visibility: {
             Row: {

--- a/src/integrations/supabase/types.d.ts
+++ b/src/integrations/supabase/types.d.ts
@@ -56,6 +56,7 @@ export type Database = {
                     delivery_failure_reason: string | null;
                     end_date: string;
                     id: string;
+                    user_id: string | null;
                     start_date: string;
                     status: string;
                     total_amount: number;
@@ -71,6 +72,7 @@ export type Database = {
                     delivery_failure_reason?: string | null;
                     end_date: string;
                     id?: string;
+                    user_id?: string | null;
                     start_date: string;
                     status?: string;
                     total_amount: number;
@@ -86,12 +88,21 @@ export type Database = {
                     delivery_failure_reason?: string | null;
                     end_date?: string;
                     id?: string;
+                    user_id?: string | null;
                     start_date?: string;
                     status?: string;
                     total_amount?: number;
                     updated_at?: string;
                 };
-                Relationships: [];
+                Relationships: [
+                    {
+                        foreignKeyName: "bookings_user_id_fkey";
+                        columns: ["user_id"];
+                        isOneToOne: false;
+                        referencedRelation: "profiles";
+                        referencedColumns: ["id"];
+                    }
+                ];
             };
             component_visibility: {
                 Row: {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -61,6 +61,7 @@ export type Database = {
           delivery_failure_reason: string | null
           end_date: string
           id: string
+          user_id: string | null
           start_date: string
           status: string
           total_amount: number
@@ -76,6 +77,7 @@ export type Database = {
           delivery_failure_reason?: string | null
           end_date: string
           id?: string
+          user_id?: string | null
           start_date: string
           status?: string
           total_amount: number
@@ -91,12 +93,21 @@ export type Database = {
           delivery_failure_reason?: string | null
           end_date?: string
           id?: string
+          user_id?: string | null
           start_date?: string
           status?: string
           total_amount?: number
           updated_at?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "bookings_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          }
+        ]
       }
       component_visibility: {
         Row: {

--- a/src/lib/queries/bookings.d.ts
+++ b/src/lib/queries/bookings.d.ts
@@ -9,6 +9,7 @@ export declare const getBookings: (userId: string) => Promise<import("@supabase/
     delivery_failure_reason: string | null;
     end_date: string;
     id: string;
+    user_id: string | null;
     start_date: string;
     status: string;
     total_amount: number;
@@ -24,6 +25,7 @@ export declare const insertBooking: (booking: Omit<Booking, "id">) => Promise<im
     delivery_failure_reason: string | null;
     end_date: string;
     id: string;
+    user_id: string | null;
     start_date: string;
     status: string;
     total_amount: number;
@@ -39,6 +41,7 @@ export declare const updateBookingStatus: (bookingId: string, newStatus: Booking
     delivery_failure_reason: string | null;
     end_date: string;
     id: string;
+    user_id: string | null;
     start_date: string;
     status: string;
     total_amount: number;

--- a/src/lib/queries/types.ts
+++ b/src/lib/queries/types.ts
@@ -9,6 +9,7 @@ export interface Booking {
   customer_email: string;
   customer_phone: string;
   customer_address: string;
+  user_id: string;
   assigned_to: string | null;
   delivery_failure_reason: string | null;
   updated_at: string;

--- a/src/types/supabase.d.ts
+++ b/src/types/supabase.d.ts
@@ -56,6 +56,7 @@ export type Database = {
                     delivery_failure_reason: string | null;
                     end_date: string;
                     id: string;
+                    user_id: string | null;
                     start_date: string;
                     status: string;
                     total_amount: number;
@@ -71,6 +72,7 @@ export type Database = {
                     delivery_failure_reason?: string | null;
                     end_date: string;
                     id?: string;
+                    user_id?: string | null;
                     start_date: string;
                     status?: string;
                     total_amount: number;
@@ -86,12 +88,21 @@ export type Database = {
                     delivery_failure_reason?: string | null;
                     end_date?: string;
                     id?: string;
+                    user_id?: string | null;
                     start_date?: string;
                     status?: string;
                     total_amount?: number;
                     updated_at?: string;
                 };
-                Relationships: [];
+                Relationships: [
+                    {
+                        foreignKeyName: "bookings_user_id_fkey";
+                        columns: ["user_id"];
+                        isOneToOne: false;
+                        referencedRelation: "profiles";
+                        referencedColumns: ["id"];
+                    }
+                ];
             };
             component_visibility: {
                 Row: {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -61,6 +61,7 @@ export type Database = {
           delivery_failure_reason: string | null
           end_date: string
           id: string
+          user_id: string | null
           start_date: string
           status: string
           total_amount: number
@@ -76,6 +77,7 @@ export type Database = {
           delivery_failure_reason?: string | null
           end_date: string
           id?: string
+          user_id?: string | null
           start_date: string
           status?: string
           total_amount: number
@@ -91,12 +93,21 @@ export type Database = {
           delivery_failure_reason?: string | null
           end_date?: string
           id?: string
+          user_id?: string | null
           start_date?: string
           status?: string
           total_amount?: number
           updated_at?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "bookings_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          }
+        ]
       }
       component_visibility: {
         Row: {

--- a/supabase/migrations/20250820000000_add_user_id_to_bookings.sql
+++ b/supabase/migrations/20250820000000_add_user_id_to_bookings.sql
@@ -1,0 +1,23 @@
+-- Add user_id column to bookings and update RLS policies
+ALTER TABLE public.bookings
+ADD COLUMN user_id uuid REFERENCES public.profiles(id);
+
+-- Backfill existing rows using profile email if possible
+UPDATE public.bookings b
+SET user_id = p.id
+FROM public.profiles p
+WHERE b.user_id IS NULL AND p.email = b.customer_email;
+
+-- Replace email-based Booker policy with user_id-based policy
+DROP POLICY IF EXISTS "Bookings: Bookers can manage their bookings by email" ON public.bookings;
+
+CREATE POLICY "Bookings: Bookers can manage their bookings by user_id" ON public.bookings
+FOR ALL
+USING (
+  user_id = auth.uid() AND
+  (EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'Booker'))
+)
+WITH CHECK (
+  user_id = auth.uid() AND
+  (EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'Booker'))
+);


### PR DESCRIPTION
## Summary
- link bookings to profiles via new `user_id` column and RLS policy
- include current user's ID when creating bookings
- expand Supabase and query types to expose `user_id`

## Testing
- `npm run lint` (fails: Unexpected any, No-useless-escape)
- `npm test` (fails: TypeError: Cannot read properties of undefined (reading 'alloc'))

------
https://chatgpt.com/codex/tasks/task_e_68a46315dc9c832bae7b429e6b5a67e8