### PR TITLE
Ensure booking status updates return equipment details

### DIFF
--- a/src/lib/queries/bookings.d.ts
+++ b/src/lib/queries/bookings.d.ts
@@ -52,6 +52,23 @@ export declare const updateBookingStatus: (bookingId: string, newStatus: Booking
         id: string;
         quantity: number;
         subtotal: number;
-        products: import("node_modules/@supabase/postgrest-js/dist/cjs/select-query-parser/utils").SelectQueryError<"could not find the relation between booking_items and products">;
+        equipment: {
+            availability: boolean;
+            availability_status: string | null;
+            category: string | null;
+            category_id: string | null;
+            created_at: string;
+            description: string | null;
+            featured: boolean;
+            id: string;
+            images: string[] | null;
+            name: string;
+            price_per_day: number;
+            sort_order: number | null;
+            stock_quantity: number;
+            sub_category: string | null;
+            sub_category_id: string | null;
+            updated_at: string;
+        } | null;
     }[];
 }>;

--- a/src/lib/queries/bookings.test.ts
+++ b/src/lib/queries/bookings.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { updateBookingStatus } from './bookings';
+import type { BookingStatus } from '@/components/admin/calendar/types';
+
+// Mock the Supabase client used in the query utilities
+const singleFn = vi.fn();
+const selectFn = vi.fn(() => ({ single: singleFn }));
+const eqFn = vi.fn(() => ({ select: selectFn }));
+const updateFn = vi.fn(() => ({ eq: eqFn }));
+const fromFn = vi.fn(() => ({ update: updateFn }));
+const invokeFn = vi.fn().mockResolvedValue({ error: null });
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: fromFn,
+    functions: { invoke: invokeFn },
+  },
+}));
+
+describe('updateBookingStatus', () => {
+  beforeEach(() => {
+    singleFn.mockReset();
+    selectFn.mockClear();
+  });
+
+  it('includes equipment details in the updated booking', async () => {
+    const mockBooking = {
+      id: '1',
+      customer_email: null,
+      booking_items: [
+        {
+          equipment_name: 'Stroller',
+          quantity: 1,
+          equipment_price: 10,
+          equipment_id: 'eq1',
+          subtotal: 10,
+          equipment: { id: 'eq1', name: 'Stroller', price_per_day: 10 },
+        },
+      ],
+    };
+
+    singleFn.mockResolvedValue({ data: mockBooking, error: null });
+
+    const result = await updateBookingStatus('1', 'confirmed' as BookingStatus);
+
+    expect(selectFn).toHaveBeenCalledWith('*, booking_items(*, equipment(*))');
+    expect(result?.booking_items[0].equipment?.name).toBe('Stroller');
+  });
+});
+

--- a/src/lib/queries/bookings.ts
+++ b/src/lib/queries/bookings.ts
@@ -23,7 +23,7 @@ export const updateBookingStatus = async (bookingId: string, newStatus: BookingS
       .from('bookings')
       .update({ status: newStatus, updated_at: new Date().toISOString() })
       .eq('id', bookingId)
-      .select('*, booking_items(*, products(*))') // Changed equipment(*) to products(*)
+      .select('*, booking_items(*, equipment(*))')
       .single();
 
     if (updateError) {


### PR DESCRIPTION
## Summary
- fetch equipment details with booking items when updating booking status
- update query types to expose nested equipment data
- add a unit test covering equipment details after status updates

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'alloc))*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a463259528832b878d6fd0f5b7da86