### PR TITLE
Add customer comment field to bookings

### DIFF
--- a/src/components/admin/BookingCard.tsx
+++ b/src/components/admin/BookingCard.tsx
@@ -3,7 +3,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card'; // Removed CardFooter, CardHeader, CardTitle
 import { Booking } from './calendar/types'; // Removed BookingItem
-import { Eye, Edit, Mail, Phone, MapPin, CalendarDays } from 'lucide-react'; // Added icon imports, using CalendarDays for clarity
+import { Eye, Edit, Mail, Phone, MapPin, CalendarDays, MessageSquare } from 'lucide-react'; // Added icon imports, using CalendarDays for clarity
 import { getStatusColor } from './calendar/statusUtils'; // Added back getStatusColor import
 
 interface BookingCardProps {
@@ -161,6 +161,12 @@ export const BookingCard = ({ booking, onStatusUpdate, onEdit, onView }: Booking
               <MapPin className="h-4 w-4" />
               <span>{booking.customer_address}</span>
             </div>
+            {booking.customer_comment && (
+              <div className="flex items-start gap-2 text-gray-600">
+                <MessageSquare className="h-4 w-4 mt-1" />
+                <span className="whitespace-pre-wrap">{booking.customer_comment}</span>
+              </div>
+            )}
             <div className="flex items-center gap-2 text-gray-600">
               <CalendarDays className="h-4 w-4" /> {/* Changed to CalendarDays */}
               <span>

--- a/src/components/admin/BookingDetailsCard.tsx
+++ b/src/components/admin/BookingDetailsCard.tsx
@@ -75,6 +75,12 @@ export const BookingDetailsCard = ({ booking }: BookingDetailsCardProps) => {
             </div>
           </div>
         </div>
+        {booking.customer_comment && (
+          <div className="mt-4">
+            <h3 className="font-semibold mb-1">Customer Comments</h3>
+            <p className="text-sm text-gray-700 whitespace-pre-wrap">{booking.customer_comment}</p>
+          </div>
+        )}
 
         {/* Equipment Items */}
         {booking.booking_items && booking.booking_items.length > 0 && (

--- a/src/components/admin/calendar/types.ts
+++ b/src/components/admin/calendar/types.ts
@@ -18,6 +18,7 @@ export interface Booking {
   customer_email: string;
   customer_phone: string;
   customer_address: string;
+  customer_comment: string | null;
   start_date: string;
   end_date: string;
   status: BookingStatus;

--- a/src/components/admin/edit-booking/types.ts
+++ b/src/components/admin/edit-booking/types.ts
@@ -21,6 +21,7 @@ export interface CustomerInfo {
   email: string;
   phone: string;
   address: string;
+  comment?: string;
 }
 
 // You can also re-export the canonical types if they are used directly

--- a/src/components/booking/CustomerInformation.tsx
+++ b/src/components/booking/CustomerInformation.tsx
@@ -2,6 +2,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import { Mail } from 'lucide-react';
 
 interface CustomerInfo {
@@ -9,6 +10,7 @@ interface CustomerInfo {
   email: string;
   phone: string;
   address: string;
+  comment: string;
 }
 
 interface CustomerInformationProps {
@@ -65,6 +67,14 @@ export const CustomerInformation = ({
             value={customerInfo.address}
             onChange={(e) => onCustomerInfoChange('address', e.target.value)}
             required
+          />
+        </div>
+        <div className="md:col-span-2">
+          <Label htmlFor="comment">Comments</Label>
+          <Textarea
+            id="comment"
+            value={customerInfo.comment}
+            onChange={(e) => onCustomerInfoChange('comment', e.target.value)}
           />
         </div>
       </CardContent>

--- a/src/hooks/useBooking.ts
+++ b/src/hooks/useBooking.ts
@@ -17,7 +17,8 @@ const initialBookingData: BookingFormData = {
     name: '',
     email: '',
     phone: '',
-    address: ''
+    address: '',
+    comment: ''
   }
 };
 
@@ -238,13 +239,14 @@ const useBooking = () => {
         return;
       }
 
-      const bookingPayload: Omit<SupabaseBookingData, 'user_id' | 'created_at' | 'total_price' | 'customer_address'> & { customer_address: string } = {
+      const bookingPayload: Omit<SupabaseBookingData, 'user_id' | 'created_at' | 'total_price'> = {
         start_date: bookingData.startDate,
         end_date: bookingData.endDate,
         customer_name: bookingData.customerInfo.name,
         customer_email: bookingData.customerInfo.email,
         customer_phone: bookingData.customerInfo.phone,
-        customer_address: bookingData.customerInfo.address, // Ensured as string
+        customer_address: bookingData.customerInfo.address,
+        customer_comment: bookingData.customerInfo.comment || null,
         total_amount: calculateTotal(), // Corrected function call
         status: 'pending', // Default status
         // items will be handled by booking_items table

--- a/src/integrations/supabase/client.d.ts
+++ b/src/integrations/supabase/client.d.ts
@@ -49,6 +49,7 @@ export declare const supabase: import("@supabase/supabase-js").SupabaseClient<Da
                 customer_email: string;
                 customer_name: string;
                 customer_phone: string;
+                customer_comment: string | null;
                 delivery_failure_reason: string | null;
                 end_date: string;
                 id: string;
@@ -64,6 +65,7 @@ export declare const supabase: import("@supabase/supabase-js").SupabaseClient<Da
                 customer_email: string;
                 customer_name: string;
                 customer_phone: string;
+                customer_comment?: string | null;
                 delivery_failure_reason?: string | null;
                 end_date: string;
                 id?: string;
@@ -79,6 +81,7 @@ export declare const supabase: import("@supabase/supabase-js").SupabaseClient<Da
                 customer_email?: string;
                 customer_name?: string;
                 customer_phone?: string;
+                customer_comment?: string | null;
                 delivery_failure_reason?: string | null;
                 end_date?: string;
                 id?: string;

--- a/src/integrations/supabase/types.d.ts
+++ b/src/integrations/supabase/types.d.ts
@@ -53,6 +53,7 @@ export type Database = {
                     customer_email: string;
                     customer_name: string;
                     customer_phone: string;
+                    customer_comment: string | null;
                     delivery_failure_reason: string | null;
                     end_date: string;
                     id: string;
@@ -68,6 +69,7 @@ export type Database = {
                     customer_email: string;
                     customer_name: string;
                     customer_phone: string;
+                    customer_comment?: string | null;
                     delivery_failure_reason?: string | null;
                     end_date: string;
                     id?: string;
@@ -83,6 +85,7 @@ export type Database = {
                     customer_email?: string;
                     customer_name?: string;
                     customer_phone?: string;
+                    customer_comment?: string | null;
                     delivery_failure_reason?: string | null;
                     end_date?: string;
                     id?: string;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -58,6 +58,7 @@ export type Database = {
           customer_email: string
           customer_name: string
           customer_phone: string
+          customer_comment: string | null
           delivery_failure_reason: string | null
           end_date: string
           id: string
@@ -73,6 +74,7 @@ export type Database = {
           customer_email: string
           customer_name: string
           customer_phone: string
+          customer_comment?: string | null
           delivery_failure_reason?: string | null
           end_date: string
           id?: string
@@ -88,6 +90,7 @@ export type Database = {
           customer_email?: string
           customer_name?: string
           customer_phone?: string
+          customer_comment?: string | null
           delivery_failure_reason?: string | null
           end_date?: string
           id?: string

--- a/src/lib/queries/bookings.d.ts
+++ b/src/lib/queries/bookings.d.ts
@@ -6,6 +6,7 @@ export declare const getBookings: (userId: string) => Promise<import("@supabase/
     customer_email: string;
     customer_name: string;
     customer_phone: string;
+    customer_comment: string | null;
     delivery_failure_reason: string | null;
     end_date: string;
     id: string;
@@ -21,6 +22,7 @@ export declare const insertBooking: (booking: Omit<Booking, "id">) => Promise<im
     customer_email: string;
     customer_name: string;
     customer_phone: string;
+    customer_comment: string | null;
     delivery_failure_reason: string | null;
     end_date: string;
     id: string;
@@ -36,6 +38,7 @@ export declare const updateBookingStatus: (bookingId: string, newStatus: Booking
     customer_email: string;
     customer_name: string;
     customer_phone: string;
+    customer_comment: string | null;
     delivery_failure_reason: string | null;
     end_date: string;
     id: string;

--- a/src/lib/queries/customers.d.ts
+++ b/src/lib/queries/customers.d.ts
@@ -6,6 +6,7 @@ export declare const getCustomer: (userId: string, bookingId: string) => Promise
     customer_email: string;
     customer_name: string;
     customer_phone: string;
+    customer_comment: string | null;
     delivery_failure_reason: string | null;
     end_date: string;
     id: string;
@@ -21,6 +22,7 @@ export declare const searchCustomers: (userId: string, searchTerm: string) => Pr
     customer_email: string;
     customer_name: string;
     customer_phone: string;
+    customer_comment: string | null;
     delivery_failure_reason: string | null;
     end_date: string;
     id: string;

--- a/src/lib/queries/types.ts
+++ b/src/lib/queries/types.ts
@@ -9,6 +9,7 @@ export interface Booking {
   customer_email: string;
   customer_phone: string;
   customer_address: string;
+  customer_comment: string | null;
   assigned_to: string | null;
   delivery_failure_reason: string | null;
   updated_at: string;

--- a/src/pages/CustomerDashboard.tsx
+++ b/src/pages/CustomerDashboard.tsx
@@ -19,6 +19,7 @@ interface CustomerBooking {
   total_amount: number;
   status: string; // Consider using a more specific type if available (e.g., from types.ts BookingStatus)
   booking_items: CustomerBookingItem[];
+  customer_comment: string | null;
 }
 
 const CustomerDashboard = () => {
@@ -37,6 +38,7 @@ const CustomerDashboard = () => {
           end_date,
           total_amount,
           status,
+          customer_comment,
           booking_items ( equipment_name, quantity )
         `)
         .eq('user_id', user.id) // Filter bookings for the current user
@@ -118,6 +120,12 @@ const CustomerDashboard = () => {
                       <p className="text-sm text-gray-600">No items in this booking.</p>
                     )}
                   </div>
+                  {booking.customer_comment && (
+                    <div>
+                      <p className="text-sm font-medium text-gray-700">Comments:</p>
+                      <p className="text-sm text-gray-600">{booking.customer_comment}</p>
+                    </div>
+                  )}
                 </CardContent>
               </Card>
             ))}

--- a/src/types/supabase.d.ts
+++ b/src/types/supabase.d.ts
@@ -53,6 +53,7 @@ export type Database = {
                     customer_email: string;
                     customer_name: string;
                     customer_phone: string;
+                    customer_comment: string | null;
                     delivery_failure_reason: string | null;
                     end_date: string;
                     id: string;
@@ -68,6 +69,7 @@ export type Database = {
                     customer_email: string;
                     customer_name: string;
                     customer_phone: string;
+                    customer_comment?: string | null;
                     delivery_failure_reason?: string | null;
                     end_date: string;
                     id?: string;
@@ -83,6 +85,7 @@ export type Database = {
                     customer_email?: string;
                     customer_name?: string;
                     customer_phone?: string;
+                    customer_comment?: string | null;
                     delivery_failure_reason?: string | null;
                     end_date?: string;
                     id?: string;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -58,6 +58,7 @@ export type Database = {
           customer_email: string
           customer_name: string
           customer_phone: string
+          customer_comment: string | null
           delivery_failure_reason: string | null
           end_date: string
           id: string
@@ -73,6 +74,7 @@ export type Database = {
           customer_email: string
           customer_name: string
           customer_phone: string
+          customer_comment?: string | null
           delivery_failure_reason?: string | null
           end_date: string
           id?: string
@@ -88,6 +90,7 @@ export type Database = {
           customer_email?: string
           customer_name?: string
           customer_phone?: string
+          customer_comment?: string | null
           delivery_failure_reason?: string | null
           end_date?: string
           id?: string

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -18,6 +18,7 @@ export interface CustomerInfo {
     email: string;
     phone: string;
     address: string;
+    comment: string;
 }
 export interface BookingFormData {
     startDate: string;
@@ -31,6 +32,7 @@ export interface SupabaseBookingData {
     customer_email: string;
     customer_phone: string;
     customer_address?: string;
+    customer_comment?: string | null;
     start_date: string;
     end_date: string;
     total_price: number;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -24,6 +24,7 @@ export interface CustomerInfo {
   email: string;
   phone: string;
   address: string;
+  comment: string;
 }
 
 // Represents the structure of the form data within the useBooking hook
@@ -41,6 +42,7 @@ export interface SupabaseBookingData {
   customer_email: string;
   customer_phone: string;
   customer_address?: string;
+  customer_comment?: string | null;
   start_date: string;
   end_date: string;
   total_price: number;

--- a/supabase/migrations/20250820000000_add_customer_comment_to_bookings.sql
+++ b/supabase/migrations/20250820000000_add_customer_comment_to_bookings.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.bookings
+ADD COLUMN customer_comment text;


### PR DESCRIPTION
## Summary
- allow customers to leave comments during booking
- store `customer_comment` in bookings table and API types
- surface comments in admin and customer booking views

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'alloc'))*

------
https://chatgpt.com/codex/tasks/task_e_68a4630859f8832b83f3b27988287f60