### PR TITLE
feat: allow editing booked equipment quantity

### DIFF
--- a/src/components/booking/BookingForm.tsx
+++ b/src/components/booking/BookingForm.tsx
@@ -17,6 +17,7 @@ export const BookingForm = () => {
     setQuantity,
     addEquipment,
     removeEquipment,
+    updateEquipmentQuantity,
     updateCustomerInfo,
     updateDates,
     calculateDays,
@@ -45,6 +46,7 @@ export const BookingForm = () => {
           setQuantity={setQuantity}
           addEquipment={addEquipment}
           removeEquipment={removeEquipment}
+          updateEquipmentQuantity={updateEquipmentQuantity}
           currentSelectedDate={bookingData.startDate ? new Date(bookingData.startDate) : undefined}
         />
 

--- a/src/components/booking/EquipmentSelection.tsx
+++ b/src/components/booking/EquipmentSelection.tsx
@@ -17,6 +17,7 @@ interface EquipmentSelectionProps {
   addEquipment: (equipment: Product, quantity: number, selectedDate: Date | undefined) => void; // Updated signature
   bookingItems: BookingItem[];
   removeEquipment: (equipment_id: string) => void;
+  updateEquipmentQuantity: (equipment_id: string, quantity: number) => void;
   currentSelectedDate?: Date | undefined; // Added prop for selected date
 }
 
@@ -29,6 +30,7 @@ const EquipmentSelection: React.FC<EquipmentSelectionProps> = ({
   addEquipment,
   bookingItems,
   removeEquipment,
+  updateEquipmentQuantity,
   currentSelectedDate // Destructure new prop
 }) => {
   const selectedProductDetails = products.find(p => p.id === selectedEquipment);
@@ -109,10 +111,20 @@ const EquipmentSelection: React.FC<EquipmentSelectionProps> = ({
                     />
                     <div>
                       <p className="font-medium">{item.equipment_name}</p>
-                      <p className="text-sm text-gray-600">
-                          Quantity: {item.quantity} × ${item.equipment_price}/day |
-                          ${Number(item.equipment_price * 5).toFixed(2)}/week {/* Use equipment_price from BookingItem */}
-                        </p>
+                      <div className="flex items-center gap-2 text-sm text-gray-600">
+                        <Input
+                          type="number"
+                          min="1"
+                          className="w-16"
+                          value={item.quantity}
+                          onChange={(e) =>
+                            updateEquipmentQuantity(item.equipment_id, parseInt(e.target.value))
+                          }
+                        />
+                        <span>
+                          × ${item.equipment_price}/day | ${Number(item.equipment_price * 5).toFixed(2)}/week {/* Use equipment_price from BookingItem */}
+                        </span>
+                      </div>
                     </div>
                   </div>
                   <Button

--- a/src/hooks/useBooking.d.ts
+++ b/src/hooks/useBooking.d.ts
@@ -7,6 +7,7 @@ declare const useBooking: () => {
     isSubmitting: boolean;
     addEquipment: (equipment: Product, quantity: number, selectedDate: Date | undefined) => void;
     removeEquipment: (equipmentId: string) => void;
+    updateEquipmentQuantity: (equipmentId: string, newQuantity: number) => void;
     updateCustomerInfo: (field: keyof CustomerInfo, value: string) => void;
     updateDates: (field: "startDate" | "endDate", value: string) => void;
     calculateTotal: () => number;

--- a/src/hooks/useBooking.ts
+++ b/src/hooks/useBooking.ts
@@ -177,6 +177,41 @@ const useBooking = () => {
     }));
   };
 
+  const updateEquipmentQuantity = (equipmentId: string, newQuantity: number) => {
+    if (isNaN(newQuantity)) return;
+
+    setBookingData(prev => {
+      const equipment = products.find(eq => eq.id === equipmentId);
+      const existingItem = prev.items.find(item => item.equipment_id === equipmentId);
+
+      if (!equipment || !existingItem) return prev;
+
+      if (newQuantity <= 0) {
+        return {
+          ...prev,
+          items: prev.items.filter(item => item.equipment_id !== equipmentId)
+        };
+      }
+
+      if (newQuantity > equipment.stock_quantity) {
+        toast({
+          title: 'Insufficient Stock',
+          description: `Only ${equipment.stock_quantity} units of ${equipment.name} available.`,
+          variant: 'destructive',
+        });
+        return prev;
+      }
+
+      const updatedItems = prev.items.map(item =>
+        item.equipment_id === equipmentId
+          ? { ...item, quantity: newQuantity, subtotal: newQuantity * item.equipment_price }
+          : item
+      );
+
+      return { ...prev, items: updatedItems };
+    });
+  };
+
   const updateCustomerInfo = (field: keyof CustomerInfo, value: string) => {
     setBookingData(prev => ({
       ...prev,
@@ -303,6 +338,7 @@ const useBooking = () => {
     isSubmitting,
     addEquipment,
     removeEquipment,
+    updateEquipmentQuantity,
     updateCustomerInfo,
     updateDates,
     calculateTotal,


### PR DESCRIPTION
## Summary
- show editable numeric inputs for each selected equipment item
- add hook logic to update booking item quantities with stock validation
- wire quantity updates through booking form and types

## Testing
- `npm test` *(fails: 7 errors)*
- `npm run lint` *(fails: 167 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a463362c7c832b8226f8d026d500ef