### PR TITLE
Show Book Now button and disable when unavailable

### DIFF
--- a/src/components/equipment/EquipmentCard.test.tsx
+++ b/src/components/equipment/EquipmentCard.test.tsx
@@ -54,4 +54,27 @@ describe('EquipmentCard', () => {
     expect(imgs).toHaveLength(equipment.images.length);
     expect(imgs[0]).toHaveAttribute('src', equipment.images[0]);
   });
+
+  it('enables booking when equipment is available', () => {
+    render(
+      <BrowserRouter>
+        <EquipmentCard equipment={equipment} />
+      </BrowserRouter>
+    );
+    const button = screen.getByRole('button', { name: /book now/i });
+    expect(button).toBeEnabled();
+    const link = screen.getByRole('link', { name: /book now/i });
+    expect(link).toBeVisible();
+  });
+
+  it('disables booking when equipment is unavailable', () => {
+    const unavailableEquipment = { ...equipment, availability: 'unavailable' as const };
+    render(
+      <BrowserRouter>
+        <EquipmentCard equipment={unavailableEquipment} />
+      </BrowserRouter>
+    );
+    const button = screen.getByRole('button', { name: /book now/i });
+    expect(button).toBeDisabled();
+  });
 });

--- a/src/components/equipment/EquipmentCard.tsx
+++ b/src/components/equipment/EquipmentCard.tsx
@@ -159,7 +159,15 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
         </CardContent>
 
         <CardFooter>
-          <Link to="/book" className="w-full hidden" hidden>
+          <Link
+            to="/book"
+            className="w-full"
+            onClick={(e) => {
+              if (equipment.availability === 'unavailable') {
+                e.preventDefault();
+              }
+            }}
+          >
             <Button
               className="w-full"
               disabled={equipment.availability === 'unavailable'}


### PR DESCRIPTION
## Summary
- Display Book Now button by removing hidden attributes from equipment card link
- Prevent navigation and disable button when equipment is unavailable
- Add tests for book button enable/disable states

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors in unrelated files)*
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'alloc'))*

------
https://chatgpt.com/codex/tasks/task_e_68a46def08d4832bae8680f0840f9eba