### PR TITLE
feat: show booking button for customers

### DIFF
--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -4,10 +4,12 @@ import { BrowserRouter } from 'react-router-dom';
 import { Header } from './Header';
 import { describe, it, expect, vi } from 'vitest';
 
+let mockProfileRole = 'Booker';
+
 vi.mock('@/hooks/useAuth', () => ({
   useAuth: () => ({
     user: { id: '1' },
-    profile: { role: 'Booker' },
+    profile: { role: mockProfileRole },
     signOut: vi.fn(),
     loading: false,
   }),
@@ -40,17 +42,25 @@ describe('Header Component', () => {
     expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute('href', '/contact');
   });
 
-  it('renders CTA button for Login only (Book Now hidden)', () => {
+  it('shows Book Now button for Booker role', () => {
+    mockProfileRole = 'Booker';
     renderHeader();
-    // The buttons are within Link components, so we find the link by its role and name (from button text)
-    // Book Now should not be rendered while booking is disabled
-    expect(screen.queryByRole('link', { name: /book now/i })).not.toBeInTheDocument();
+    const bookNowLink = screen.getByRole('link', { name: /book now/i });
+    expect(bookNowLink).toBeInTheDocument();
 
     const logoutBtn = screen.getByRole('button', { name: /logout/i });
     expect(logoutBtn).toBeInTheDocument();
   });
 
+  it('shows Book Now button for Customer role', () => {
+    mockProfileRole = 'Customer';
+    renderHeader();
+    const bookNowLink = screen.getByRole('link', { name: /book now/i });
+    expect(bookNowLink).toBeInTheDocument();
+  });
+
   it('toggles the mobile menu on button click', () => {
+    mockProfileRole = 'Booker';
     renderHeader();
     const mobileMenuButton = screen.getByRole('button', { name: /menu/i }); // Initial state shows Menu icon
     expect(mobileMenuButton).toBeInTheDocument();

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -120,9 +120,8 @@ export const Header = () => {
               <p>Loading...</p>
             ) : user && profile ? (
               <>
-                {profile.role === 'Booker' && (
-                  // Hide Book Now button until booking is enabled
-                  <Button asChild className="hidden" hidden>
+                {(profile.role === 'Booker' || profile.role === 'Customer') && (
+                  <Button asChild>
                     <Link to="/book">Book Now</Link>
                   </Button>
                 )}

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -60,4 +60,4 @@ export interface Profile {
     email: string | null;
     is_deactivated?: boolean | null;
 }
-export type UserRole = 'SuperUser' | 'Admin' | 'Booker' | 'Driver';
+export type UserRole = 'SuperUser' | 'Admin' | 'Booker' | 'Customer' | 'Driver';

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -78,6 +78,6 @@ export interface Profile {
 }
 
 // Define UserRole based on the roles in Profile
-export type UserRole = 'SuperUser' | 'Admin' | 'Booker' | 'Driver';
+export type UserRole = 'SuperUser' | 'Admin' | 'Booker' | 'Customer' | 'Driver';
 
 // You can add other shared types here as your project grows.


### PR DESCRIPTION
## Summary
- display "Book Now" for Booker and Customer roles in header
- expand user role typings to include Customer role
- test Book Now button visibility for Booker and Customer

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'alloc'))*
- `npm run lint` *(fails: 190 problems (167 errors, 23 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a46e002df8832bb97567038c7465b5