### PR TITLE
feat: add booking CTA on equipment page

### DIFF
--- a/src/pages/EquipmentItem.tsx
+++ b/src/pages/EquipmentItem.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import DOMPurify from 'dompurify';
 import { Header } from '@/components/layout/Header';
@@ -149,6 +149,22 @@ const EquipmentItem = () => {
               </ul>
             </div>
           )}
+          <Link
+            to="/book"
+            className="block mt-6"
+            onClick={(e) => {
+              if (equipment.availability === 'unavailable') {
+                e.preventDefault();
+              }
+            }}
+          >
+            <Button
+              className="w-full sm:w-auto"
+              disabled={equipment.availability === 'unavailable'}
+            >
+              Book Now
+            </Button>
+          </Link>
         </div>
       </main>
       <Footer />


### PR DESCRIPTION
## Summary
- add Book Now link on equipment detail page using existing booking flow

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'alloc'))*
- `npm run lint` *(fails: no-useless-escape, no-explicit-any, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a47068fe6c832b98c6525d425af554