### PR TITLE
fix: constrain modal image sizes

### DIFF
--- a/src/components/equipment/EquipmentCard.tsx
+++ b/src/components/equipment/EquipmentCard.tsx
@@ -180,7 +180,7 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
 
       {/* 🔵 MODAL */}
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-lg sm:max-w-xl">
+        <DialogContent className="max-w-lg sm:max-w-xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>{equipment.name}</DialogTitle>
           </DialogHeader>
@@ -189,11 +189,11 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
             <Carousel className="w-full mb-4">
               <CarouselContent>
                 {equipment.images.map((img, idx) => (
-                  <CarouselItem key={idx}>
+                  <CarouselItem key={idx} className="flex justify-center">
                     <img
                       src={img}
                       alt={`${equipment.name} image ${idx + 1}`}
-                      className="w-full h-64 object-cover rounded"
+                      className="max-w-full h-auto max-h-[60vh] object-contain rounded"
                     />
                   </CarouselItem>
                 ))}
@@ -205,7 +205,7 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
             <img
               src={equipment.image}
               alt={equipment.name}
-              className="w-full h-64 object-cover rounded mb-4"
+              className="max-w-full h-auto max-h-[60vh] object-contain rounded mb-4 mx-auto"
             />
           )}
 


### PR DESCRIPTION
## Summary
- constrain modal size and make it scrollable
- scale modal images to fit within viewport and preserve aspect ratio

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'alloc'))*
- `npm run lint` *(fails: 167 errors, 23 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a473288e4c832b8c94c4485591c833