### PR TITLE
feat: add cart context and page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { AuthProvider } from "@/hooks/useAuth";
 import { SiteAssetsProvider } from "@/hooks/useSiteAssets";
 import ProtectedRoute from "@/components/layout/ProtectedRoute";
 import { AppPrefetch } from "@/AppPrefetch"; //
+import { CartProvider } from "@/hooks/useCart";
 
 // Lazy load all pages
 const Index = lazy(() => import("./pages/Index"));
@@ -29,6 +30,7 @@ const SeoTest = lazy(() => import("./pages/SeoTest"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 const PaymentSuccess = lazy(() => import("./pages/PaymentSuccess"));
 const PaymentError = lazy(() => import("./pages/PaymentError"));
+const CartPage = lazy(() => import("./pages/Cart"));
 
 // Loading fallback
 const PageLoader = () => (
@@ -53,6 +55,7 @@ const App = () => {
       <TooltipProvider>
         <AuthProvider>
           <SiteAssetsProvider>
+            <CartProvider>
             <Toaster />
             <Sonner />
             <ErrorBoundary>
@@ -106,6 +109,7 @@ const App = () => {
                     <Route path="/seo-test" element={<SeoTest />} />
                     <Route path="/payment-success" element={<PaymentSuccess />} />
                     <Route path="/payment-error" element={<PaymentError />} />
+                    <Route path="/cart" element={<CartPage />} />
 
                     {/* Catch all */}
                     <Route path="*" element={<NotFound />} />
@@ -113,6 +117,7 @@ const App = () => {
                 </Suspense>
               </BrowserRouter>
             </ErrorBoundary>
+            </CartProvider>
           </SiteAssetsProvider>
         </AuthProvider>
       </TooltipProvider>

--- a/src/components/booking/BookingForm.tsx
+++ b/src/components/booking/BookingForm.tsx
@@ -5,6 +5,7 @@ import EquipmentSelection from './EquipmentSelection';
 import { CustomerInformation } from './CustomerInformation';
 import { BookingSummary } from './BookingSummary';
 import useBooking from '@/hooks/useBooking';
+import { useCart } from '@/hooks/useCart';
 
 export const BookingForm = () => {
   const {
@@ -15,17 +16,15 @@ export const BookingForm = () => {
     isSubmitting,
     setSelectedEquipment,
     setQuantity,
-    addEquipment,
-    removeEquipment,
-    updateEquipmentQuantity,
     updateCustomerInfo,
     updateDates,
     calculateDays,
     calculateTotal,
     submitBooking
   } = useBooking();
+  const { items } = useCart();
 
-  const showSummary = bookingData.items.length > 0 && bookingData.startDate && bookingData.endDate;
+  const showSummary = items.length > 0 && bookingData.startDate && bookingData.endDate;
 
   return (
     <div className="max-w-4xl mx-auto space-y-6">
@@ -41,12 +40,8 @@ export const BookingForm = () => {
           products={products} // Pass products to EquipmentSelection
           selectedEquipment={selectedEquipment}
           quantity={quantity}
-          bookingItems={bookingData.items}
           setSelectedEquipment={setSelectedEquipment}
           setQuantity={setQuantity}
-          addEquipment={addEquipment}
-          removeEquipment={removeEquipment}
-          updateEquipmentQuantity={updateEquipmentQuantity}
           currentSelectedDate={bookingData.startDate ? new Date(bookingData.startDate) : undefined}
         />
 
@@ -58,7 +53,7 @@ export const BookingForm = () => {
         {showSummary && (
           <BookingSummary
             days={calculateDays()}
-            itemsCount={bookingData.items.length}
+            itemsCount={items.length}
             total={calculateTotal()}
           />
         )}
@@ -67,7 +62,7 @@ export const BookingForm = () => {
           type="submit" 
           className="w-full" 
           size="lg"
-          disabled={bookingData.items.length === 0 || !bookingData.startDate || !bookingData.endDate || isSubmitting}
+          disabled={items.length === 0 || !bookingData.startDate || !bookingData.endDate || isSubmitting}
         >
           {isSubmitting ? 'Submitting...' : 'Proceed to Payment'}
         </Button>

--- a/src/components/booking/EquipmentSelection.d.ts
+++ b/src/components/booking/EquipmentSelection.d.ts
@@ -1,14 +1,11 @@
 import React from 'react';
-import { Product, BookingItem } from '@/types/types';
+import { Product } from '@/types/types';
 interface EquipmentSelectionProps {
     products: Product[];
     selectedEquipment: string;
     setSelectedEquipment: (id: string) => void;
     quantity: number;
     setQuantity: (quantity: number) => void;
-    addEquipment: (equipment: Product, quantity: number, selectedDate: Date | undefined) => void;
-    bookingItems: BookingItem[];
-    removeEquipment: (equipment_id: string) => void;
     currentSelectedDate?: Date | undefined;
 }
 declare const EquipmentSelection: React.FC<EquipmentSelectionProps>;

--- a/src/components/booking/EquipmentSelection.tsx
+++ b/src/components/booking/EquipmentSelection.tsx
@@ -5,8 +5,9 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Trash2 } from 'lucide-react';
 import React from 'react';
-import { Product, BookingItem } from '@/types/types'; // Import Product and BookingItem from types.ts
+import { Product } from '@/types/types'; // Import Product from types.ts
 import Spinner from '@/components/common/Spinner'; // Added Spinner import
+import { useCart } from '@/hooks/useCart';
 
 interface EquipmentSelectionProps {
   products: Product[];
@@ -14,10 +15,6 @@ interface EquipmentSelectionProps {
   setSelectedEquipment: (id: string) => void;
   quantity: number;
   setQuantity: (quantity: number) => void;
-  addEquipment: (equipment: Product, quantity: number, selectedDate: Date | undefined) => void; // Updated signature
-  bookingItems: BookingItem[];
-  removeEquipment: (equipment_id: string) => void;
-  updateEquipmentQuantity: (equipment_id: string, quantity: number) => void;
   currentSelectedDate?: Date | undefined; // Added prop for selected date
 }
 
@@ -27,17 +24,14 @@ const EquipmentSelection: React.FC<EquipmentSelectionProps> = ({
   setSelectedEquipment,
   quantity,
   setQuantity,
-  addEquipment,
-  bookingItems,
-  removeEquipment,
-  updateEquipmentQuantity,
   currentSelectedDate // Destructure new prop
 }) => {
+  const { items: bookingItems, addItem, removeItem, updateItemQuantity } = useCart();
   const selectedProductDetails = products.find(p => p.id === selectedEquipment);
 
   const handleAddEquipment = () => {
     if (selectedProductDetails && quantity > 0) {
-      addEquipment(selectedProductDetails, quantity, currentSelectedDate); // Pass currentSelectedDate
+      addItem(selectedProductDetails, quantity, currentSelectedDate); // Pass currentSelectedDate
     }
   };
 
@@ -118,7 +112,7 @@ const EquipmentSelection: React.FC<EquipmentSelectionProps> = ({
                           className="w-16"
                           value={item.quantity}
                           onChange={(e) =>
-                            updateEquipmentQuantity(item.equipment_id, parseInt(e.target.value))
+                            updateItemQuantity(item.equipment_id, parseInt(e.target.value))
                           }
                         />
                         <span>
@@ -131,7 +125,7 @@ const EquipmentSelection: React.FC<EquipmentSelectionProps> = ({
                     type="button"
                     variant="ghost"
                     size="sm"
-                    onClick={() => removeEquipment(item.equipment_id)}
+                    onClick={() => removeItem(item.equipment_id)}
                   >
                     <Trash2 className="h-4 w-4" />
                   </Button>

--- a/src/components/cart/Cart.tsx
+++ b/src/components/cart/Cart.tsx
@@ -1,0 +1,41 @@
+import { useCart } from '@/hooks/useCart';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Trash2 } from 'lucide-react';
+
+const Cart = () => {
+  const { items, removeItem, updateItemQuantity } = useCart();
+
+  if (items.length === 0) {
+    return <p>Your cart is empty.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {items.map(item => (
+        <div key={item.equipment_id} className="flex items-center justify-between p-4 border rounded">
+          <div>
+            <p className="font-medium">{item.equipment_name}</p>
+            <div className="flex items-center gap-2 text-sm text-gray-600">
+              <Input
+                type="number"
+                min="1"
+                className="w-16"
+                value={item.quantity}
+                onChange={(e) => updateItemQuantity(item.equipment_id, parseInt(e.target.value))}
+              />
+              <span>
+                × ${item.equipment_price}/day | ${Number(item.equipment_price * 5).toFixed(2)}/week
+              </span>
+            </div>
+          </div>
+          <Button variant="ghost" size="sm" onClick={() => removeItem(item.equipment_id)}>
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Cart;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,12 +13,15 @@ import {
   NavigationMenuList,
   NavigationMenuTrigger
 } from '@/components/ui/navigation-menu';
+import { ShoppingCart } from 'lucide-react';
+import { useCart } from '@/hooks/useCart';
 
 export const Header = () => {
   const { user, profile, signOut, loading } = useAuth();
   const { assets } = useSiteAssets();
   const { categories, loading: categoriesLoading } = useCategories();
   const navigate = useNavigate();
+  const { items } = useCart();
 
   const handleSignOut = async () => {
     await signOut();
@@ -116,6 +119,14 @@ export const Header = () => {
           </nav>
 
           <div className="hidden md:flex items-center space-x-4">
+            <Link to="/cart" className="relative">
+              <ShoppingCart className="h-6 w-6" />
+              {items.length > 0 && (
+                <span className="absolute -top-1 -right-1 text-xs bg-red-500 text-white rounded-full h-4 w-4 flex items-center justify-center">
+                  {items.length}
+                </span>
+              )}
+            </Link>
             {loading ? (
               <p>Loading...</p>
             ) : user && profile ? (

--- a/src/hooks/useBooking.d.ts
+++ b/src/hooks/useBooking.d.ts
@@ -5,9 +5,6 @@ declare const useBooking: () => {
     selectedEquipment: string;
     quantity: number;
     isSubmitting: boolean;
-    addEquipment: (equipment: Product, quantity: number, selectedDate: Date | undefined) => void;
-    removeEquipment: (equipmentId: string) => void;
-    updateEquipmentQuantity: (equipmentId: string, newQuantity: number) => void;
     updateCustomerInfo: (field: keyof CustomerInfo, value: string) => void;
     updateDates: (field: "startDate" | "endDate", value: string) => void;
     calculateTotal: () => number;

--- a/src/hooks/useCart.tsx
+++ b/src/hooks/useCart.tsx
@@ -1,0 +1,104 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { Product, BookingItem } from '@/types/types';
+import { useToast } from '@/components/ui/use-toast';
+
+interface CartContextType {
+  items: BookingItem[];
+  addItem: (equipment: Product, quantity: number, selectedDate?: Date) => void;
+  removeItem: (equipmentId: string) => void;
+  updateItemQuantity: (equipmentId: string, quantity: number) => void;
+  clearCart: () => void;
+}
+
+const CartContext = createContext<CartContextType | undefined>(undefined);
+
+export const CartProvider = ({ children }: { children: ReactNode }) => {
+  const [items, setItems] = useState<BookingItem[]>([]);
+  const { toast } = useToast();
+
+  const addItem = (equipment: Product, quantity: number, selectedDate?: Date) => {
+    if (!selectedDate) {
+      toast({
+        title: 'Date Not Selected',
+        description: 'Please select a date before adding equipment.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (equipment.stock_quantity < quantity) {
+      toast({
+        title: 'Insufficient Stock',
+        description: `Only ${equipment.stock_quantity} units of ${equipment.name} available.`,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setItems(prev => {
+      const existing = prev.find(item => item.equipment_id === equipment.id);
+      if (existing) {
+        if (equipment.stock_quantity < existing.quantity + quantity) {
+          toast({
+            title: 'Insufficient Stock for Cart Update',
+            description: `Cannot add ${quantity} more unit(s) of ${equipment.name}. Available: ${equipment.stock_quantity}, In cart: ${existing.quantity}.`,
+            variant: 'destructive',
+          });
+          return prev;
+        }
+        return prev.map(item =>
+          item.equipment_id === equipment.id
+            ? {
+                ...item,
+                quantity: item.quantity + quantity,
+                subtotal: (item.quantity + quantity) * item.equipment_price,
+              }
+            : item
+        );
+      }
+
+      const price = equipment.price_per_day ?? 0;
+      const newItem: BookingItem = {
+        equipment_id: equipment.id,
+        quantity,
+        equipment_price: price,
+        equipment_name: equipment.name,
+        subtotal: price * quantity,
+      };
+      return [...prev, newItem];
+    });
+  };
+
+  const removeItem = (equipmentId: string) => {
+    setItems(prev => prev.filter(item => item.equipment_id !== equipmentId));
+  };
+
+  const updateItemQuantity = (equipmentId: string, quantity: number) => {
+    if (isNaN(quantity)) return;
+    setItems(prev =>
+      prev.map(item =>
+        item.equipment_id === equipmentId
+          ? { ...item, quantity, subtotal: quantity * item.equipment_price }
+          : item
+      )
+    );
+  };
+
+  const clearCart = () => setItems([]);
+
+  return (
+    <CartContext.Provider value={{ items, addItem, removeItem, updateItemQuantity, clearCart }}>
+      {children}
+    </CartContext.Provider>
+  );
+};
+
+export const useCart = () => {
+  const context = useContext(CartContext);
+  if (context === undefined) {
+    throw new Error('useCart must be used within a CartProvider');
+  }
+  return context;
+};
+
+export default useCart;

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,0 +1,20 @@
+import { Header } from '@/components/layout/Header';
+import { Footer } from '@/components/layout/Footer';
+import Cart from '@/components/cart/Cart';
+
+const CartPage = () => {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+          <h1 className="text-4xl font-bold text-gray-900 mb-8">Your Cart</h1>
+          <Cart />
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default CartPage;


### PR DESCRIPTION
## Summary
- create CartContext for shared booking items
- add cart page and header link
- refactor booking flow to use global cart state

## Testing
- `npm test` (fails: TypeError reading 'alloc')
- `npm run lint` (fails: multiple lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68a475cb5834832b89b087a35fe31510