### PR TITLE
Allow equipment selection before choosing dates

### DIFF
--- a/src/components/booking/EquipmentSelection.tsx
+++ b/src/components/booking/EquipmentSelection.tsx
@@ -14,7 +14,7 @@ interface EquipmentSelectionProps {
   setSelectedEquipment: (id: string) => void;
   quantity: number;
   setQuantity: (quantity: number) => void;
-  addEquipment: (equipment: Product, quantity: number, selectedDate: Date | undefined) => void; // Updated signature
+  addEquipment: (equipment: Product, quantity: number, selectedDate?: Date) => void; // Updated signature
   bookingItems: BookingItem[];
   removeEquipment: (equipment_id: string) => void;
   updateEquipmentQuantity: (equipment_id: string, quantity: number) => void;

--- a/src/hooks/useBooking.d.ts
+++ b/src/hooks/useBooking.d.ts
@@ -5,7 +5,7 @@ declare const useBooking: () => {
     selectedEquipment: string;
     quantity: number;
     isSubmitting: boolean;
-    addEquipment: (equipment: Product, quantity: number, selectedDate: Date | undefined) => void;
+    addEquipment: (equipment: Product, quantity: number, selectedDate?: Date) => void;
     removeEquipment: (equipmentId: string) => void;
     updateEquipmentQuantity: (equipmentId: string, newQuantity: number) => void;
     updateCustomerInfo: (field: keyof CustomerInfo, value: string) => void;

--- a/src/hooks/useBooking.ts
+++ b/src/hooks/useBooking.ts
@@ -98,16 +98,7 @@ const useBooking = () => {
     fetchProducts();
   }, [toast]);
 
-  const addEquipment = (equipment: Product, quantity: number, selectedDate: Date | undefined) => {
-    if (!selectedDate) {
-      toast({
-        title: 'Date Not Selected',
-        description: 'Please select a date before adding equipment.',
-        variant: 'destructive',
-      });
-      return;
-    }
-
+  const addEquipment = (equipment: Product, quantity: number, selectedDate?: Date) => {
     if (!equipment || !equipment.id) {
       toast({
         title: 'Equipment Not Selected',
@@ -115,6 +106,13 @@ const useBooking = () => {
         variant: 'destructive',
       });
       return;
+    }
+
+    if (!selectedDate) {
+      toast({
+        title: 'Dates Not Selected',
+        description: 'Equipment added. Select rental dates to see final pricing.'
+      });
     }
 
     // Stock check (assuming equipment.stock_quantity is available)
@@ -169,7 +167,7 @@ const useBooking = () => {
     });
 
     // Reset selection (optional, depends on UI flow)
-    // setSelectedEquipment(''); 
+    // setSelectedEquipment('');
     // setQuantity(1);
   };
 
@@ -237,10 +235,8 @@ const useBooking = () => {
   };
 
   const calculateTotal = () => {
-    if (!bookingData.startDate || !bookingData.endDate) return 0;
-    
-    const days = calculateDays();
-    
+    const days = bookingData.startDate && bookingData.endDate ? calculateDays() : 1;
+
     return bookingData.items.reduce((total, item) => {
       const equipment = products.find(eq => eq.id === item.equipment_id); // Changed from product_id
       return total + (equipment ? equipment.price_per_day * item.quantity * days : 0);


### PR DESCRIPTION
## Summary
- Allow adding equipment without selected dates and show an info toast
- Compute booking totals using a default single day when dates are missing

## Testing
- `npm run lint` *(fails: Unnecessary escape characters and numerous type errors)*
- `npm test` *(fails: 8 errors, tests watching for changes)*

------
https://chatgpt.com/codex/tasks/task_e_68a475c8e9ac832ba4d23ed3c7ac62ee