### PR TITLE
feat: preload equipment selection from quick booking

### DIFF
--- a/src/components/booking/BookingForm.tsx
+++ b/src/components/booking/BookingForm.tsx
@@ -1,15 +1,17 @@
 
+import { useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { DateSelection } from './DateSelection';
 import EquipmentSelection from './EquipmentSelection';
 import { CustomerInformation } from './CustomerInformation';
 import { BookingSummary } from './BookingSummary';
 import useBooking from '@/hooks/useBooking';
+import { useSearchParams } from 'react-router-dom';
 
 export const BookingForm = () => {
   const {
     bookingData,
-    products, // Destructure products from useBooking
+    products,
     selectedEquipment,
     quantity,
     isSubmitting,
@@ -24,6 +26,18 @@ export const BookingForm = () => {
     calculateTotal,
     submitBooking
   } = useBooking();
+
+  const [searchParams] = useSearchParams();
+  const equipmentId = searchParams.get('equipmentId');
+
+  useEffect(() => {
+    if (equipmentId && products.length > 0) {
+      const match = products.find(p => p.id === equipmentId);
+      if (match) {
+        setSelectedEquipment(equipmentId);
+      }
+    }
+  }, [equipmentId, products, setSelectedEquipment]);
 
   const showSummary = bookingData.items.length > 0 && bookingData.startDate && bookingData.endDate;
 

--- a/src/components/booking/QuickBooking.d.ts
+++ b/src/components/booking/QuickBooking.d.ts
@@ -1,1 +1,4 @@
-export declare const QuickBooking: () => import("react/jsx-runtime").JSX.Element;
+export interface QuickBookingProps {
+  equipmentId?: string;
+}
+export declare const QuickBooking: ({ equipmentId }: QuickBookingProps) => import("react/jsx-runtime").JSX.Element;

--- a/src/components/booking/QuickBooking.tsx
+++ b/src/components/booking/QuickBooking.tsx
@@ -6,11 +6,11 @@ import { Badge } from '@/components/ui/badge';
 import { Calendar, Clock } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
-// interface QuickBookingProps { // Removed unused interface
-//   // equipmentId?: string; // Removed unused prop
-// }
+interface QuickBookingProps {
+  equipmentId?: string;
+}
 
-export const QuickBooking = (/*{ equipmentId }: QuickBookingProps*/) => { // Removed unused prop
+export const QuickBooking = ({ equipmentId }: QuickBookingProps) => {
   const [selectedDates, setSelectedDates] = useState({
     startDate: '',
     endDate: ''
@@ -74,8 +74,10 @@ export const QuickBooking = (/*{ equipmentId }: QuickBookingProps*/) => { // Rem
             24/7 Support
           </Badge>
         </div>
-
-        <Link to="/book" className="w-full">
+        <Link
+          to={equipmentId ? `/book?equipmentId=${equipmentId}` : '/book'}
+          className="w-full"
+        >
           <Button className="w-full" size="lg">
             Continue Booking
           </Button>


### PR DESCRIPTION
## Summary
- pass equipmentId to booking link in QuickBooking
- pre-select equipment in BookingForm when equipmentId query is present

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'alloc'))*
- `npm run lint` *(fails: 190 problems (167 errors, 23 warnings))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a475d151d4832b9a93d8b6b9954414