### PR TITLE
fix: preserve category selection for featured products

### DIFF
--- a/src/components/homepage/FeaturedProducts.tsx
+++ b/src/components/homepage/FeaturedProducts.tsx
@@ -68,7 +68,14 @@ export const FeaturedProducts = () => {
                                     ${Number(product.price_per_day).toFixed(2)}/day |
                                     ${Number(product.price_per_day * 5).toFixed(2)}/week
                                 </div>
-                                <Link to="/equipment" className="block">
+                                <Link
+                                    to={
+                                        product.category
+                                            ? `/equipment?category=${encodeURIComponent(product.category)}`
+                                            : '/equipment'
+                                    }
+                                    className="block"
+                                >
                                     <Button className="w-full">View All</Button>
                                 </Link>
                             </CardContent>

--- a/src/components/homepage/FeaturedProducts.tsx
+++ b/src/components/homepage/FeaturedProducts.tsx
@@ -70,8 +70,8 @@ export const FeaturedProducts = () => {
                                 </div>
                                 <Link
                                     to={
-                                        product.category
-                                            ? `/equipment?category=${encodeURIComponent(product.category)}`
+                                        product.equipment_category?.name
+                                            ? `/equipment?category=${encodeURIComponent(product.equipment_category.name)}`
                                             : '/equipment'
                                     }
                                     className="block"

--- a/src/lib/queries/products.ts
+++ b/src/lib/queries/products.ts
@@ -25,7 +25,10 @@ export const getProducts = async () => {
 export const getFeaturedProducts = async () => {
   const { data, error } = await supabase
     .from('equipment')
-    .select('*')
+    .select(`
+      *,
+      equipment_category (name)
+    `)
     .eq('featured', true)
     .order('featured_sort_order', { ascending: true })
     .order('created_at', { ascending: false });


### PR DESCRIPTION
## Summary
- ensure highlighted equipment links maintain their category when navigating to the equipment page

## Testing
- `npm test -- --run` *(fails: Cannot read properties of undefined (reading 'alloc'))*
- `npm run lint` *(fails: 189 problems (166 errors, 23 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a703ada9b0832b9231a808a75be6a0