### PR TITLE
refactor: replace product_id with equipment_id

### DIFF
--- a/src/components/admin/CustomersList.tsx
+++ b/src/components/admin/CustomersList.tsx
@@ -46,9 +46,9 @@ export const CustomersList = () => {
           *,
           booking_items (
             id,
-            product_id,
+            equipment_id,
             quantity,
-            price_per_day,
+            equipment_price,
             subtotal,
             equipment_name
           )

--- a/src/hooks/useBooking.ts
+++ b/src/hooks/useBooking.ts
@@ -131,7 +131,7 @@ const useBooking = () => {
     const days = calculateDays();
     
     return bookingData.items.reduce((total, item) => {
-      const equipment = products.find(eq => eq.id === item.equipment_id); // Changed from product_id
+      const equipment = products.find(eq => eq.id === item.equipment_id);
       return total + (equipment ? equipment.price_per_day * item.quantity * days : 0);
     }, 0);
   };

--- a/src/types/booking.d.ts
+++ b/src/types/booking.d.ts
@@ -7,6 +7,5 @@ export interface SupabaseBookingItemData {
     equipment_price: number;
     price_at_booking: number;
     subtotal: number;
-    product_id: string;
     created_at?: string;
 }

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -42,12 +42,11 @@ export interface SupabaseBookingData {
 }
 export interface SupabaseBookingItemData {
     booking_id: string;
-    product_id: string;
-    quantity: number;
-    price_at_booking: number;
     equipment_id: string;
     equipment_name: string;
     equipment_price: number;
+    quantity: number;
+    price_at_booking: number;
     subtotal: number;
 }
 export type { Booking, BookingItem, BookingStatus };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -54,12 +54,11 @@ export interface SupabaseBookingData {
 // Defines the structure for data submitted to Supabase 'booking_items' table
 export interface SupabaseBookingItemData {
   booking_id: string;
-  product_id: string;
-  quantity: number;
-  price_at_booking: number;
   equipment_id: string;
   equipment_name: string;
   equipment_price: number;
+  quantity: number;
+  price_at_booking: number;
   subtotal: number;
 }
 


### PR DESCRIPTION
## Summary
- remove product_id from SupabaseBookingItemData types
- update CustomersList booking_items query to use equipment_id fields
- clean up references to product_id in booking logic

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'alloc'))*
- `npm run lint` *(fails: 192 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a70d55b56c832ba5049f50b15796b0