### PR TITLE
Handle bookings without payment session

### DIFF
--- a/src/components/booking/BookingForm.tsx
+++ b/src/components/booking/BookingForm.tsx
@@ -76,13 +76,13 @@ export const BookingForm = () => {
           />
         )}
 
-        <Button 
-          type="submit" 
-          className="w-full" 
+        <Button
+          type="submit"
+          className="w-full"
           size="lg"
           disabled={items.length === 0 || !bookingData.startDate || !bookingData.endDate || isSubmitting}
         >
-          {isSubmitting ? 'Submitting...' : 'Proceed to Payment'}
+          {isSubmitting ? 'Submitting...' : 'Submit Booking'}
         </Button>
       </form>
     </div>

--- a/src/hooks/useBooking.ts
+++ b/src/hooks/useBooking.ts
@@ -221,28 +221,16 @@ const useBooking = () => {
         return;
       }
 
-      // Create payment session
-      const { data: paymentData, error: paymentError } = await supabase.functions.invoke<{ paymentUrl: string }>(
-        'create-payment-session',
-        {
-          body: {
-            bookingId: bookingInsertData.id,
-            amount: calculateTotal(),
-            successUrl: `${window.location.origin}/payment-success?booking_id=${bookingInsertData.id}`,
-            cancelUrl: `${window.location.origin}/payment-error?booking_id=${bookingInsertData.id}`,
-          },
-        },
-      );
-
-      if (paymentError || !paymentData?.paymentUrl) {
-        toast({ title: 'Payment Error', description: 'Could not initiate payment.', variant: 'destructive' });
-        setIsSubmitting(false);
-        return;
-      }
-
+      // Booking and items inserted successfully; clear cart and reset form
       setBookingData(initialBookingData);
+      setSelectedEquipment('');
+      setQuantity(1);
       clearCart();
-      window.location.href = paymentData.paymentUrl;
+
+      toast({
+        title: 'Booking Submitted',
+        description: 'Your booking has been received. We will contact you to arrange payment.',
+      });
       return;
     } catch (error) {
       toast({ title: 'Unexpected Error', description: 'An unexpected error occurred.', variant: 'destructive' });


### PR DESCRIPTION
## Summary
- remove create-payment-session call and redirect
- clear cart, reset form, and show toast after booking insert
- rename booking form submit button to "Submit Booking"

## Testing
- `npm run lint` *(fails: Unnecessary escape character and unexpected any errors)*
- `npm test` *(fails: Cannot read properties of undefined (reading 'alloc'))*


------
https://chatgpt.com/codex/tasks/task_e_68a70d437530832b8ea7a597613bdffe