### PR TITLE
Add cart-based booking and Book Now links

### DIFF
--- a/src/components/equipment/EquipmentCard.test.tsx
+++ b/src/components/equipment/EquipmentCard.test.tsx
@@ -12,6 +12,14 @@ vi.mock('@/components/ui/carousel', () => ({
   CarouselNext: () => null,
 }));
 
+vi.mock('@/hooks/useCart', () => ({
+  useCart: () => ({ addItem: vi.fn() })
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: '1' } })
+}));
+
 const equipment = {
   id: '1',
   name: 'Tent',
@@ -63,8 +71,6 @@ describe('EquipmentCard', () => {
     );
     const button = screen.getByRole('button', { name: /book now/i });
     expect(button).toBeEnabled();
-    const link = screen.getByRole('link', { name: /book now/i });
-    expect(link).toBeVisible();
   });
 
   it('disables booking when equipment is unavailable', () => {

--- a/src/components/equipment/EquipmentCard.tsx
+++ b/src/components/equipment/EquipmentCard.tsx
@@ -1,13 +1,16 @@
 import { useState, useMemo } from 'react';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext } from '@/components/ui/carousel';
 import clsx from 'clsx';
 import DOMPurify from 'dompurify';
 import { Share2 } from 'lucide-react';
 import { toast } from '@/components/ui/use-toast';
+import { useCart } from '@/hooks/useCart';
+import { useAuth } from '@/hooks/useAuth';
+import type { Product } from '@/types/types';
 
 interface Equipment {
   id: string;
@@ -77,6 +80,31 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
     } catch (err) {
       console.error('Share failed', err);
     }
+  };
+
+  const { addItem } = useCart();
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  const handleBook = () => {
+    if (equipment.availability === 'unavailable') return;
+    const destination = `/book?equipmentId=${equipment.id}`;
+    if (!user) {
+      navigate(`/login?redirect=${encodeURIComponent(destination)}`);
+      return;
+    }
+
+    const product: Product = {
+      id: equipment.id,
+      name: equipment.name,
+      description: equipment.description,
+      price_per_day: equipment.price,
+      category: equipment.category,
+      images: equipment.images,
+      stock_quantity: 1,
+    };
+    addItem(product, 1, new Date());
+    navigate(destination);
   };
 
   return (
@@ -159,22 +187,13 @@ export const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
         </CardContent>
 
         <CardFooter>
-          <Link
-            to="/book"
+          <Button
             className="w-full"
-            onClick={(e) => {
-              if (equipment.availability === 'unavailable') {
-                e.preventDefault();
-              }
-            }}
+            disabled={equipment.availability === 'unavailable'}
+            onClick={handleBook}
           >
-            <Button
-              className="w-full"
-              disabled={equipment.availability === 'unavailable'}
-            >
-              Book Now
-            </Button>
-          </Link>
+            Book Now
+          </Button>
         </CardFooter>
       </Card>
 

--- a/src/components/layout/Footer.test.tsx
+++ b/src/components/layout/Footer.test.tsx
@@ -2,7 +2,11 @@
 import { render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { Footer } from './Footer';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: null })
+}));
 
 describe('Footer Component', () => {
   // it('should be a basic passing test', () => {
@@ -39,7 +43,6 @@ describe('Footer Component', () => {
     );
     // Use exact match for the main "Equipment" link to avoid multiple matches
     expect(screen.getByRole('link', { name: /^Equipment$/i })).toBeInTheDocument();
-    // Book Now link is hidden; ensure it is not rendered
-    expect(screen.queryByRole('link', { name: /Book Now/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Book Now/i })).toBeInTheDocument();
   });
 });

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,7 +1,9 @@
 
 import { Link } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
 
 export const Footer = () => {
+  const { user } = useAuth();
   return (
     <footer className="bg-gray-900 text-white">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
@@ -25,9 +27,13 @@ export const Footer = () => {
             <h3 className="text-lg font-semibold mb-4">Quick Links</h3>
             <ul className="space-y-2 text-gray-400">
               <li><Link to="/equipment" className="hover:text-white transition-colors">Equipment</Link></li>
-              {/* Temporarily hide booking link until feature is available */}
-              <li hidden className="hidden">
-                <Link to="/book" className="hover:text-white transition-colors">Book Now</Link>
+              <li>
+                <Link
+                  to={user ? '/book' : '/login?redirect=/book'}
+                  className="hover:text-white transition-colors"
+                >
+                  Book Now
+                </Link>
               </li>
               <li><Link to="/about" className="hover:text-white transition-colors">About Us</Link></li>
               <li><Link to="/contact" className="hover:text-white transition-colors">Contact</Link></li>

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -129,6 +129,7 @@ const MobileNav = () => {
               </div>
             </CollapsibleContent>
           </Collapsible>
+          <NavLink to={user ? '/book' : '/login?redirect=/book'}>Book Now</NavLink>
           <NavLink to="/about">About</NavLink>
           <NavLink to="/contact">Contact</NavLink>
           {(loading || (user && profile)) && (
@@ -137,12 +138,6 @@ const MobileNav = () => {
                 <p className="px-3 py-2 text-gray-700">Loading...</p>
               ) : (
                 <div className="space-y-2">
-                  {profile.role === 'Booker' && (
-                    // Hide Book Now option for now
-                    <Button asChild className="w-full hidden" hidden onClick={() => setIsOpen(false)}>
-                      <Link to="/book">Book Now</Link>
-                    </Button>
-                  )}
                   {dashboardLink && (
                     <Button asChild variant="outline" className="w-full" onClick={() => setIsOpen(false)}>
                       <Link to={dashboardLink.path}>{dashboardLink.label}</Link>


### PR DESCRIPTION
## Summary
- Add cart integration for equipment booking and redirect unauthenticated users to login
- Navigate to book page with equipment ID and protect booking actions
- Expose global Book Now links in mobile nav and footer

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'alloc'))*
- `npm run lint` *(fails: 192 problems (167 errors, 25 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a71bb39b08832baaa4f6265d92952a