### PR TITLE
security: require staff auth on email and Cloudflare edge functions

### DIFF
--- a/src/lib/services/cloudflareImageService.ts
+++ b/src/lib/services/cloudflareImageService.ts
@@ -29,6 +29,17 @@ class CloudflareImageService {
     this.supabaseKey = import.meta.env.VITE_PUBLIC_SUPABASE_ANON_KEY || '';
   }
 
+  // The cloudflare-images-proxy function is staff-gated, so requests must carry
+  // the signed-in user's access token, not the public anon key. Resolve it from
+  // the current session at call time.
+  private async authHeader(): Promise<string> {
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.access_token) {
+      throw new Error('You must be signed in to manage images.');
+    }
+    return `Bearer ${session.access_token}`;
+  }
+
   async listImages(page = 1, perPage = 50, continuationToken?: string): Promise<CloudflareImagesResponse> {
     try {
       const params = new URLSearchParams({
@@ -47,7 +58,7 @@ class CloudflareImageService {
           headers: {
             'Content-Type': 'application/json',
             apikey: this.supabaseKey,
-            Authorization: `Bearer ${this.supabaseKey}`,
+            Authorization: await this.authHeader(),
           },
         }
       );
@@ -76,7 +87,7 @@ class CloudflareImageService {
           headers: {
             'Content-Type': 'application/json',
             apikey: this.supabaseKey,
-            Authorization: `Bearer ${this.supabaseKey}`,
+            Authorization: await this.authHeader(),
           },
         }
       );

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,0 +1,91 @@
+// supabase/functions/_shared/auth.ts
+//
+// Shared authorization gate for edge functions that must only be callable by
+// authenticated staff. Mirrors the vetted pattern in create-user-with-otp /
+// admin-user-operations: validate the caller's JWT, then check profiles.role
+// against a whitelist using a service-role client (so the lookup is not itself
+// filtered by RLS).
+//
+// Why this exists: Supabase's platform `verify_jwt` only requires *any*
+// project-signed JWT, and the public anon key (shipped in the frontend bundle)
+// is such a JWT. Without this gate, any holder of the anon key can invoke these
+// functions. `requireRole` closes that by requiring a real user session whose
+// profile role is permitted.
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { corsHeaders } from './cors.ts';
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+export interface StaffCaller {
+  id: string;
+  role: string;
+  email: string | null;
+}
+
+export type AuthResult =
+  | { ok: true; caller: StaffCaller }
+  | { ok: false; response: Response };
+
+// Named role groups so each function reads declaratively. Roles match the
+// assignable set in create-user-with-otp (Customer is intentionally excluded
+// from every staff group).
+export const OFFICE_ROLES = ['Admin', 'SuperUser', 'Booker'] as const;
+export const BILLING_ROLES = ['Admin', 'SuperUser', 'Booker', 'Accounting'] as const;
+export const STAFF_ROLES = ['Admin', 'SuperUser', 'Booker', 'Accounting', 'StoreStaff', 'Driver'] as const;
+
+/**
+ * Verify the request comes from an authenticated user whose profiles.role is in
+ * `allowedRoles`. On failure returns a ready-to-return 401/403 Response that
+ * only says Unauthorized/Forbidden (no detail leak). On success returns the
+ * caller's id, role, and email.
+ */
+export async function requireRole(
+  req: Request,
+  allowedRoles: readonly string[],
+): Promise<AuthResult> {
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return { ok: false, response: jsonResponse({ error: 'Missing authorization header' }, 401) };
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+
+  // Caller-scoped client: validates the JWT actually presented in the request.
+  const supabaseUser = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const { data: userData, error: userError } = await supabaseUser.auth.getUser();
+  if (userError || !userData.user) {
+    return { ok: false, response: jsonResponse({ error: 'Unauthorized' }, 401) };
+  }
+
+  // Service-role client for the role lookup only — used after the caller's
+  // identity is established, never with caller-supplied input.
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const { data: profile, error: profileError } = await supabaseAdmin
+    .from('profiles')
+    .select('role')
+    .eq('id', userData.user.id)
+    .single();
+
+  if (profileError || !profile || !allowedRoles.includes(profile.role)) {
+    return { ok: false, response: jsonResponse({ error: 'Forbidden' }, 403) };
+  }
+
+  return {
+    ok: true,
+    caller: { id: userData.user.id, role: profile.role, email: userData.user.email ?? null },
+  };
+}

--- a/supabase/functions/booking-status-update-email/index.ts
+++ b/supabase/functions/booking-status-update-email/index.ts
@@ -1,5 +1,6 @@
 /// <reference lib="deno.ns" />
 import { corsHeaders } from '../_shared/cors.ts';
+import { requireRole, STAFF_ROLES } from '../_shared/auth.ts';
 
 const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
 const RESEND_API_URL = 'https://api.resend.com/emails';
@@ -22,6 +23,9 @@ Deno.serve(async (req: Request) => {
   }
 
   try {
+    const auth = await requireRole(req, STAFF_ROLES);
+    if (!auth.ok) return auth.response;
+
     const {
       customer_email,
       customer_name,

--- a/supabase/functions/cloudflare-image-upload/index.ts
+++ b/supabase/functions/cloudflare-image-upload/index.ts
@@ -1,5 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { corsHeaders } from '../_shared/cors.ts';
+import { requireRole, OFFICE_ROLES } from '../_shared/auth.ts';
 
 Deno.serve(async (req: Request) => {
   // Handle CORS preflight requests
@@ -18,6 +19,9 @@ Deno.serve(async (req: Request) => {
   }
 
   try {
+    const auth = await requireRole(req, OFFICE_ROLES);
+    if (!auth.ok) return auth.response;
+
     // Get Cloudflare credentials from environment
     const accountId = Deno.env.get('CLOUDFLARE_ACCOUNT_ID');
     const apiToken = Deno.env.get('CLOUDFLARE_API_TOKEN');

--- a/supabase/functions/cloudflare-images-proxy/index.ts
+++ b/supabase/functions/cloudflare-images-proxy/index.ts
@@ -1,6 +1,7 @@
 // Cloudflare Images Proxy Edge Function
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { corsHeaders } from '../_shared/cors.ts';
+import { requireRole, OFFICE_ROLES } from '../_shared/auth.ts';
 
 Deno.serve(async (req: Request) => {
   // Handle CORS preflight requests
@@ -9,6 +10,9 @@ Deno.serve(async (req: Request) => {
   }
 
   try {
+    const auth = await requireRole(req, OFFICE_ROLES);
+    if (!auth.ok) return auth.response;
+
     const url = new URL(req.url);
     const page = url.searchParams.get('page') || '1';
     const per_page = url.searchParams.get('per_page') || '50';

--- a/supabase/functions/driver-assignment-email/index.ts
+++ b/supabase/functions/driver-assignment-email/index.ts
@@ -1,5 +1,6 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import { corsHeaders } from '../_shared/cors.ts';
+import { requireRole, OFFICE_ROLES } from '../_shared/auth.ts';
 
 const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
 const RESEND_API_URL = 'https://api.resend.com/emails';
@@ -34,6 +35,9 @@ serve(async (req: Request) => {
   }
 
   try {
+    const auth = await requireRole(req, OFFICE_ROLES);
+    if (!auth.ok) return auth.response;
+
     const payload = await req.json() as AssignmentPayload;
     const { driver, booking } = payload;
 

--- a/supabase/functions/send-collection-receipt-email/index.ts
+++ b/supabase/functions/send-collection-receipt-email/index.ts
@@ -2,6 +2,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'jsr:@supabase/supabase-js@2';
 
 import { corsHeaders } from '../_shared/cors.ts';
+import { requireRole, STAFF_ROLES } from '../_shared/auth.ts';
 
 const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
 const RESEND_API_URL = 'https://api.resend.com/emails';
@@ -43,6 +44,9 @@ serve(async (req) => {
   }
 
   try {
+    const auth = await requireRole(req, STAFF_ROLES);
+    if (!auth.ok) return auth.response;
+
     const requestData = await req.json() as CollectionReceiptRequest;
 
     if (!requestData.collection_receipt_id) {

--- a/supabase/functions/send-delivery-proof-email/index.ts
+++ b/supabase/functions/send-delivery-proof-email/index.ts
@@ -2,6 +2,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'jsr:@supabase/supabase-js@2';
 
 import { corsHeaders } from '../_shared/cors.ts';
+import { requireRole, STAFF_ROLES } from '../_shared/auth.ts';
 
 const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
 const RESEND_API_URL = 'https://api.resend.com/emails';
@@ -44,6 +45,9 @@ serve(async (req) => {
   }
 
   try {
+    const auth = await requireRole(req, STAFF_ROLES);
+    if (!auth.ok) return auth.response;
+
     const requestData = await req.json() as DeliveryProofRequest;
 
     if (!requestData.delivery_slip_id) {

--- a/supabase/functions/send-delivery-tracking-email/index.ts
+++ b/supabase/functions/send-delivery-tracking-email/index.ts
@@ -2,6 +2,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'jsr:@supabase/supabase-js@2';
 
 import { corsHeaders } from '../_shared/cors.ts';
+import { requireRole, STAFF_ROLES } from '../_shared/auth.ts';
 
 const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
 const RESEND_API_URL = 'https://api.resend.com/emails';
@@ -39,6 +40,9 @@ serve(async (req) => {
   }
 
   try {
+    const auth = await requireRole(req, STAFF_ROLES);
+    if (!auth.ok) return auth.response;
+
     const requestData = await req.json() as DeliveryTrackingRequest;
 
     if (!requestData.task_id) {

--- a/supabase/functions/send-invoice-email/index.ts
+++ b/supabase/functions/send-invoice-email/index.ts
@@ -2,6 +2,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'jsr:@supabase/supabase-js@2';
 
 import { corsHeaders } from '../_shared/cors.ts';
+import { requireRole, BILLING_ROLES } from '../_shared/auth.ts';
 
 const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
 const RESEND_API_URL = 'https://api.resend.com/emails';
@@ -54,6 +55,9 @@ serve(async (req) => {
   }
 
   try {
+    const auth = await requireRole(req, BILLING_ROLES);
+    if (!auth.ok) return auth.response;
+
     const requestData: InvoiceEmailRequest = await req.json();
     const invoice = await resolveInvoiceSnapshot(requestData);
 

--- a/supabase/functions/send-payment-link-email/index.ts
+++ b/supabase/functions/send-payment-link-email/index.ts
@@ -1,5 +1,6 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { corsHeaders } from '../_shared/cors.ts';
+import { requireRole, OFFICE_ROLES } from '../_shared/auth.ts';
 
 const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
 const RESEND_API_URL = 'https://api.resend.com/emails';
@@ -19,6 +20,9 @@ serve(async (req) => {
   }
 
   try {
+    const auth = await requireRole(req, OFFICE_ROLES);
+    if (!auth.ok) return auth.response;
+
     const requestData: PaymentLinkEmailRequest = await req.json();
     
     const {

--- a/supabase/functions/send-rejection-email/index.ts
+++ b/supabase/functions/send-rejection-email/index.ts
@@ -1,5 +1,6 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { corsHeaders } from '../_shared/cors.ts';
+import { requireRole, OFFICE_ROLES } from '../_shared/auth.ts';
 
 const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
 const RESEND_API_URL = 'https://api.resend.com/emails';
@@ -18,6 +19,9 @@ serve(async (req) => {
   }
 
   try {
+    const auth = await requireRole(req, OFFICE_ROLES);
+    if (!auth.ok) return auth.response;
+
     const requestData: RejectionEmailRequest = await req.json();
     
     const {


### PR DESCRIPTION
## What
Closes the MEDIUM audit item: email + Cloudflare edge functions were invokable by anyone holding the public anon key (which ships in the frontend bundle and satisfies Supabase's default `verify_jwt`). No role check existed, allowing arbitrary branded emails (phishing payment links, rejection/invoice notices) and Cloudflare image upload/listing.

## Change
New shared gate `_shared/auth.ts` (`requireRole`) mirroring the vetted `create-user-with-otp` pattern: JWT → `getUser()` → `profiles.role` whitelist via a service-role client. Applied to:

| Function | Allowed roles |
|---|---|
| send-payment-link-email, send-rejection-email, driver-assignment-email, cloudflare-image-upload, cloudflare-images-proxy | Admin / SuperUser / Booker |
| send-invoice-email | + Accounting |
| booking-status-update-email, send-collection-receipt-email, send-delivery-proof-email, send-delivery-tracking-email | all non-Customer staff (incl. Driver) |

`cloudflareImageService` now forwards the signed-in user's access token instead of the hardcoded anon key, so the staff image UI keeps working behind the gate. Email callers already invoke via supabase-js, which attaches the session token automatically. Fails safe: missing/invalid session → 401, wrong role → 403, with a friendly UI message for the image service.

## Explicitly out of scope
- **send-booking-confirmation** left open — it serves the guest public booking flow; needs a bot/rate-limit control (Turnstile) or booking-scoped token, not a role gate. Pending product decision.
- Dead functions with no callers (booking-confirmation-email, send-reservation-email) flagged for removal, not touched here.
- Live-RLS item untouched — under Cristian's 07-31 risk-acceptance.

## Verification
- Full vitest suite: 146 passing; the only 2 failures (SubGroupOrderSettings) and 3 tsc errors (DynamicMap) are pre-existing on the clean base, unrelated to this diff.
- Zero live writes / no deploy. Deno not available locally; gate code is copied verbatim from the deployed, working create-user-with-otp function.