### PR TITLE
security(rls): mirror prod RLS hardening + lock down equipment_sub_category

### DIFF
--- a/supabase/migrations/20260801155000_harden_rls_policies.sql
+++ b/supabase/migrations/20260801155000_harden_rls_policies.sql
@@ -1,0 +1,30 @@
+-- Security hardening applied to production 2026-08-01.
+-- 1) Remove permissive "allow all" policies on bookings/booking_items: combined with RLS
+--    they granted anon full read/write/delete on both tables (June 2026 audit critical).
+-- 2) Restrict Driver/Booker profile visibility to authenticated users: the policies were
+--    created without a role restriction, exposing staff id/name/email/role to anon.
+-- Idempotent: safe to re-run and safe on databases where these policies never existed.
+
+drop policy if exists "Allow all operations on bookings" on public.bookings;
+drop policy if exists "Allow all operations on booking_items" on public.booking_items;
+
+do $$
+begin
+  if exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'profiles'
+      and policyname = 'Profiles: Authenticated users can view Driver profiles'
+  ) then
+    alter policy "Profiles: Authenticated users can view Driver profiles"
+      on public.profiles to authenticated;
+  end if;
+
+  if exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'profiles'
+      and policyname = 'Profiles: Authenticated users can view Booker profiles'
+  ) then
+    alter policy "Profiles: Authenticated users can view Booker profiles"
+      on public.profiles to authenticated;
+  end if;
+end $$;

--- a/supabase/migrations/20260801160000_enable_rls_equipment_sub_category.sql
+++ b/supabase/migrations/20260801160000_enable_rls_equipment_sub_category.sql
@@ -1,0 +1,35 @@
+-- Enable RLS on equipment_sub_category (the only table found with RLS off on live prod,
+-- 2026-08-01 audit). Low risk: contents are public catalog data. Mirror exactly how
+-- equipment_category is handled (see 20260627202800_add_category_to_equipment.sql):
+-- admins/superusers manage all rows, everyone can read.
+-- Idempotent: safe to re-run.
+
+alter table public.equipment_sub_category enable row level security;
+
+drop policy if exists "Admins can manage all equipment sub categories" on public.equipment_sub_category;
+drop policy if exists "Public can view all equipment sub categories" on public.equipment_sub_category;
+
+-- Policy for Admins/SuperUsers to manage sub categories
+create policy "Admins can manage all equipment sub categories"
+on public.equipment_sub_category
+for all
+using (
+  exists (
+    select 1
+    from public.profiles
+    where id = auth.uid() and role in ('Admin', 'SuperUser')
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.profiles
+    where id = auth.uid() and role in ('Admin', 'SuperUser')
+  )
+);
+
+-- Policy for public to view sub categories
+create policy "Public can view all equipment sub categories"
+on public.equipment_sub_category
+for select
+using (true);


### PR DESCRIPTION
Mirrors the RLS hardening that was applied directly to **production** on 2026-08-01 (main migration `20260801155000`, commit 4c0ab89) into the `test_environment` source, so a fresh DB build from this branch is not vulnerable. Also closes the last table with RLS off on live.

## Migrations

### `20260801155000_harden_rls_policies.sql` (byte-identical copy of main)
- Drops the permissive `"Allow all operations on bookings"` / `"Allow all operations on booking_items"` policies. Combined with RLS these granted anon full read/write/delete (June 2026 audit critical). Not defined in this branch's migrations (legacy/manual on prod), but the `drop policy if exists` makes the mirror clean and safe for fresh builds.
- `ALTER` the `"Profiles: Authenticated users can view Driver profiles"` and `"...Booker profiles"` policies `TO authenticated`. These were created in `20260316000000` without a role restriction, exposing staff id/name/email/role to **anon**. Guarded by `pg_policies` existence checks.

### `20260801160000_enable_rls_equipment_sub_category.sql` (new)
- Enables RLS on `equipment_sub_category` — the only table found with RLS off on live prod.
- Adds admin/superuser manage-all + public-read policies, matching exactly how `equipment_category` is handled (`20260627202800`). Public-read alone would have blocked admin writes to sub-categories.

All statements are idempotent and safe on databases where the policies never existed.

## Publishable-key swap (local, not in this diff)
The Supabase anon key lives only in the gitignored `.env` + the Vercel dashboard — there is no hardcoded key in tracked source, and `src/integrations/supabase/client.ts` reads it from `import.meta.env`. So the legacy→publishable swap is an env-value change, no code change.

- Swapped the **local test_environment** `.env` `VITE_PUBLIC_SUPABASE_ANON_KEY` to the new publishable key `sb_publishable_1cBEhTGBCkdpZC6gBpqUGA_vzSp-0H5` (public-safe). Legacy JWT kept commented for rollback.
- **Live deploy env is untouched** — the live-key swap + legacy-key kill switch are gated on Cristian.
- **Flag for the live cutover:** the Vercel **test_environment** deploy env still carries the legacy anon key — swap it to the publishable key there too so the deployed test build matches local. Live prod deploy env is Cristian's call.

## Verification (read-only, zero writes to prod)
- REST probe with the publishable key: `equipment_category` → `200` + rows; `profiles` as anon → `200` + `[]` (staff PII stays locked).
- Booted the app in a browser against the new key: `0` console errors, Supabase client initialized cleanly, all data reads (`equipment`, `equipment_category`, `equipment_sub_category`, content) returned `200`. Page rendered fully.
