### PR TITLE
fix(validation): align envSchema to real VITE_PUBLIC_SUPABASE_* var names

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -115,8 +115,8 @@ export const searchSchema = z.object({
 
 // Environment variable validation
 export const envSchema = z.object({
-  VITE_SUPABASE_URL: z.string().url('Invalid Supabase URL'),
-  VITE_SUPABASE_ANON_KEY: z.string().min(1, 'Supabase anon key is required'),
+  VITE_PUBLIC_SUPABASE_URL: z.string().url('Invalid Supabase URL'),
+  VITE_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1, 'Supabase anon key is required'),
   CLOUDFLARE_IMAGES_HASH: z.string().min(1, 'Cloudflare images hash is required').optional()
 });
 


### PR DESCRIPTION
## What
Renames the two Supabase keys in the exported `envSchema` (in `src/utils/validation.ts`) from `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` to the names the app actually uses: **`VITE_PUBLIC_SUPABASE_URL`** / **`VITE_PUBLIC_SUPABASE_ANON_KEY`**.

## Why
The real Supabase client (`src/integrations/supabase/client.ts`), `cloudflareImageService.ts`, `setupTests.ts`, and `.env.example` all use the `VITE_PUBLIC_SUPABASE_*` names. The `envSchema`/`validateEnv` helpers referenced the non-prefixed names.

**No runtime/behavior change:** `envSchema`/`validateEnv` are exported but never imported or called anywhere in the codebase (verified by grep), so they never ran. The fix removes a latent trap: if these helpers were ever wired into startup validation, they'd validate variables nobody sets and give false confidence. This aligns them to reality.

## Scope
- Only the two Supabase var names are touched.
- The optional `CLOUDFLARE_IMAGES_HASH` field is left as-is (separate concern, out of scope for this cleanup).

## Context
Follow-up to today's live RLS hardening + publishable-key rotation. Flagged while swapping the live Supabase key on Vercel.